### PR TITLE
Use ISO 8601 in the Receivers API

### DIFF
--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -222,7 +222,7 @@ func (api *API) getReceiversHandler(params receiver_ops.GetReceiversParams) midd
 			integrations = append(integrations, &open_api_models.Integration{
 				Name:               &iname,
 				SendResolve:        &sendResolved,
-				LastNotify:         notify.UTC().String(),
+				LastNotify:         strfmt.DateTime(notify.UTC()),
 				LastNotifyDuration: duration.String(),
 				LastError: func() string {
 					if err != nil {

--- a/api/v2/models/integration.go
+++ b/api/v2/models/integration.go
@@ -35,7 +35,8 @@ type Integration struct {
 	LastError string `json:"lastError,omitempty"`
 
 	// last notify
-	LastNotify string `json:"lastNotify,omitempty"`
+	// Format: date-time
+	LastNotify strfmt.DateTime `json:"lastNotify,omitempty"`
 
 	// last notify duration
 	LastNotifyDuration string `json:"lastNotifyDuration,omitempty"`
@@ -53,6 +54,10 @@ type Integration struct {
 func (m *Integration) Validate(formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.validateLastNotify(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateName(formats); err != nil {
 		res = append(res, err)
 	}
@@ -64,6 +69,19 @@ func (m *Integration) Validate(formats strfmt.Registry) error {
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *Integration) validateLastNotify(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.LastNotify) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("lastNotify", "body", "date-time", m.LastNotify.String(), formats); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/api/v2/openapi.yaml
+++ b/api/v2/openapi.yaml
@@ -525,6 +525,7 @@ definitions:
         type: boolean
       lastNotify:
         type: string
+        format: date-time
       lastNotifyDuration:
         type: string
       lastError:

--- a/api/v2/restapi/embedded_spec.go
+++ b/api/v2/restapi/embedded_spec.go
@@ -610,7 +610,8 @@ func init() {
           "type": "string"
         },
         "lastNotify": {
-          "type": "string"
+          "type": "string",
+          "format": "date-time"
         },
         "lastNotifyDuration": {
           "type": "string"
@@ -1459,7 +1460,8 @@ func init() {
           "type": "string"
         },
         "lastNotify": {
-          "type": "string"
+          "type": "string",
+          "format": "date-time"
         },
         "lastNotifyDuration": {
           "type": "string"


### PR DESCRIPTION
This PR formats the `lastNotify` field in the `/receivers` response to use the ISO 8601 format.
In case of having no value for this field, it defaults to the zero value for a date in this format. Example:

```json
{
    "active": true,
    "integrations": [
        {
            "lastNotify": "0001-01-01T00:00:00.000Z", <- ISO 8601
            "lastNotifyDuration": "0s",
            "name": "email[0]",
            "sendResolve": false
        }
    ],
    "name": "Email"
}
```