### PR TITLE
Fix: typo in spec

### DIFF
--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -221,7 +221,7 @@ func (api *API) getReceiversHandler(params receiver_ops.GetReceiversParams) midd
 			sendResolved := integration.SendResolved()
 			integrations = append(integrations, &open_api_models.Integration{
 				Name:               &iname,
-				SendResolve:        &sendResolved,
+				SendResolved:       &sendResolved,
 				LastNotify:         strfmt.DateTime(notify.UTC()),
 				LastNotifyDuration: duration.String(),
 				LastError: func() string {

--- a/api/v2/models/integration.go
+++ b/api/v2/models/integration.go
@@ -45,9 +45,9 @@ type Integration struct {
 	// Required: true
 	Name *string `json:"name"`
 
-	// send resolve
+	// send resolved
 	// Required: true
-	SendResolve *bool `json:"sendResolve"`
+	SendResolved *bool `json:"sendResolved"`
 }
 
 // Validate validates this integration
@@ -62,7 +62,7 @@ func (m *Integration) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
-	if err := m.validateSendResolve(formats); err != nil {
+	if err := m.validateSendResolved(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -94,9 +94,9 @@ func (m *Integration) validateName(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *Integration) validateSendResolve(formats strfmt.Registry) error {
+func (m *Integration) validateSendResolved(formats strfmt.Registry) error {
 
-	if err := validate.Required("sendResolve", "body", m.SendResolve); err != nil {
+	if err := validate.Required("sendResolved", "body", m.SendResolved); err != nil {
 		return err
 	}
 

--- a/api/v2/openapi.yaml
+++ b/api/v2/openapi.yaml
@@ -521,7 +521,7 @@ definitions:
     properties:
       name:
         type: string
-      sendResolve:
+      sendResolved:
         type: boolean
       lastNotify:
         type: string
@@ -532,7 +532,7 @@ definitions:
         type: string
     required:
       - name
-      - sendResolve
+      - sendResolved
   labelSet:
     type: object
     additionalProperties:

--- a/api/v2/restapi/embedded_spec.go
+++ b/api/v2/restapi/embedded_spec.go
@@ -603,7 +603,7 @@ func init() {
       "type": "object",
       "required": [
         "name",
-        "sendResolve"
+        "sendResolved"
       ],
       "properties": {
         "lastError": {
@@ -619,7 +619,7 @@ func init() {
         "name": {
           "type": "string"
         },
-        "sendResolve": {
+        "sendResolved": {
           "type": "boolean"
         }
       }
@@ -1453,7 +1453,7 @@ func init() {
       "type": "object",
       "required": [
         "name",
-        "sendResolve"
+        "sendResolved"
       ],
       "properties": {
         "lastError": {
@@ -1469,7 +1469,7 @@ func init() {
         "name": {
           "type": "string"
         },
-        "sendResolve": {
+        "sendResolved": {
           "type": "boolean"
         }
       }


### PR DESCRIPTION
In the Receivers API, `sendResolve` should be `sendResolved` in order to be coherent with the rest of the AM codebase.
This typo was introduced in the [Receivers API PR](https://github.com/grafana/prometheus-alertmanager/pull/8).