### PR TITLE
Clear names for receivers API fields

### DIFF
--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -220,11 +220,11 @@ func (api *API) getReceiversHandler(params receiver_ops.GetReceiversParams) midd
 			iname := integration.String()
 			sendResolved := integration.SendResolved()
 			integrations = append(integrations, &open_api_models.Integration{
-				Name:               &iname,
-				SendResolved:       &sendResolved,
-				LastNotify:         strfmt.DateTime(notify.UTC()),
-				LastNotifyDuration: duration.String(),
-				LastError: func() string {
+				Name:                &iname,
+				SendResolved:        &sendResolved,
+				LastAttempt:         strfmt.DateTime(notify.UTC()),
+				LastAttemptDuration: duration.String(),
+				LastAttemptError: func() string {
 					if err != nil {
 						return err.Error()
 					}

--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -220,11 +220,11 @@ func (api *API) getReceiversHandler(params receiver_ops.GetReceiversParams) midd
 			iname := integration.String()
 			sendResolved := integration.SendResolved()
 			integrations = append(integrations, &open_api_models.Integration{
-				Name:                &iname,
-				SendResolved:        &sendResolved,
-				LastAttempt:         strfmt.DateTime(notify.UTC()),
-				LastAttemptDuration: duration.String(),
-				LastAttemptError: func() string {
+				Name:                      &iname,
+				SendResolved:              &sendResolved,
+				LastNotifyAttempt:         strfmt.DateTime(notify.UTC()),
+				LastNotifyAttemptDuration: duration.String(),
+				LastNotifyAttemptError: func() string {
 					if err != nil {
 						return err.Error()
 					}

--- a/api/v2/api_test.go
+++ b/api/v2/api_test.go
@@ -17,7 +17,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -205,7 +205,7 @@ func TestDeleteSilenceHandler(t *testing.T) {
 			HTTPRequest: r,
 		})
 		responder.WriteResponse(w, p)
-		body, _ := ioutil.ReadAll(w.Result().Body)
+		body, _ := io.ReadAll(w.Result().Body)
 
 		require.Equal(t, tc.expectedCode, w.Code, fmt.Sprintf("test case: %d, response: %s", i, string(body)))
 	}
@@ -305,7 +305,7 @@ func TestPostSilencesHandler(t *testing.T) {
 			Silence:     &sil,
 		})
 		responder.WriteResponse(w, p)
-		body, _ := ioutil.ReadAll(w.Result().Body)
+		body, _ := io.ReadAll(w.Result().Body)
 
 		require.Equal(t, tc.expectedCode, w.Code, fmt.Sprintf("test case: %d, response: %s", i, string(body)))
 	}

--- a/api/v2/models/integration.go
+++ b/api/v2/models/integration.go
@@ -33,13 +33,13 @@ type Integration struct {
 
 	// A timestamp indicating the last attempt to deliver a notification regardless of the outcome.
 	// Format: date-time
-	LastAttempt strfmt.DateTime `json:"lastAttempt,omitempty"`
+	LastNotifyAttempt strfmt.DateTime `json:"lastNotifyAttempt,omitempty"`
 
 	// Duration of the last attempt to deliver a notification in humanized format (`1s` or `15ms`, etc).
-	LastAttemptDuration string `json:"lastAttemptDuration,omitempty"`
+	LastNotifyAttemptDuration string `json:"lastNotifyAttemptDuration,omitempty"`
 
-	// Error string for the last attempt to deliver a notification. Empty If the last attempt was successful.
-	LastAttemptError string `json:"lastAttemptError,omitempty"`
+	// Error string for the last attempt to deliver a notification. Empty if the last attempt was successful.
+	LastNotifyAttemptError string `json:"lastNotifyAttemptError,omitempty"`
 
 	// name
 	// Required: true
@@ -54,7 +54,7 @@ type Integration struct {
 func (m *Integration) Validate(formats strfmt.Registry) error {
 	var res []error
 
-	if err := m.validateLastAttempt(formats); err != nil {
+	if err := m.validateLastNotifyAttempt(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -72,13 +72,13 @@ func (m *Integration) Validate(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *Integration) validateLastAttempt(formats strfmt.Registry) error {
+func (m *Integration) validateLastNotifyAttempt(formats strfmt.Registry) error {
 
-	if swag.IsZero(m.LastAttempt) { // not required
+	if swag.IsZero(m.LastNotifyAttempt) { // not required
 		return nil
 	}
 
-	if err := validate.FormatOf("lastAttempt", "body", "date-time", m.LastAttempt.String(), formats); err != nil {
+	if err := validate.FormatOf("lastNotifyAttempt", "body", "date-time", m.LastNotifyAttempt.String(), formats); err != nil {
 		return err
 	}
 

--- a/api/v2/models/integration.go
+++ b/api/v2/models/integration.go
@@ -31,14 +31,14 @@ import (
 // swagger:model integration
 type Integration struct {
 
-	// last attempt
+	// A timestamp indicating the last attempt to deliver a notification regardless of the outcome.
 	// Format: date-time
 	LastAttempt strfmt.DateTime `json:"lastAttempt,omitempty"`
 
-	// last attempt duration
+	// Duration of the last attempt to deliver a notification in humanized format (`1s` or `15ms`, etc).
 	LastAttemptDuration string `json:"lastAttemptDuration,omitempty"`
 
-	// last attempt error
+	// Error string for the last attempt to deliver a notification. Empty If the last attempt was successful.
 	LastAttemptError string `json:"lastAttemptError,omitempty"`
 
 	// name

--- a/api/v2/models/integration.go
+++ b/api/v2/models/integration.go
@@ -31,15 +31,15 @@ import (
 // swagger:model integration
 type Integration struct {
 
-	// last error
-	LastError string `json:"lastError,omitempty"`
-
-	// last notify
+	// last attempt
 	// Format: date-time
-	LastNotify strfmt.DateTime `json:"lastNotify,omitempty"`
+	LastAttempt strfmt.DateTime `json:"lastAttempt,omitempty"`
 
-	// last notify duration
-	LastNotifyDuration string `json:"lastNotifyDuration,omitempty"`
+	// last attempt duration
+	LastAttemptDuration string `json:"lastAttemptDuration,omitempty"`
+
+	// last attempt error
+	LastAttemptError string `json:"lastAttemptError,omitempty"`
 
 	// name
 	// Required: true
@@ -54,7 +54,7 @@ type Integration struct {
 func (m *Integration) Validate(formats strfmt.Registry) error {
 	var res []error
 
-	if err := m.validateLastNotify(formats); err != nil {
+	if err := m.validateLastAttempt(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -72,13 +72,13 @@ func (m *Integration) Validate(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *Integration) validateLastNotify(formats strfmt.Registry) error {
+func (m *Integration) validateLastAttempt(formats strfmt.Registry) error {
 
-	if swag.IsZero(m.LastNotify) { // not required
+	if swag.IsZero(m.LastAttempt) { // not required
 		return nil
 	}
 
-	if err := validate.FormatOf("lastNotify", "body", "date-time", m.LastNotify.String(), formats); err != nil {
+	if err := validate.FormatOf("lastAttempt", "body", "date-time", m.LastAttempt.String(), formats); err != nil {
 		return err
 	}
 

--- a/api/v2/openapi.yaml
+++ b/api/v2/openapi.yaml
@@ -523,12 +523,12 @@ definitions:
         type: string
       sendResolved:
         type: boolean
-      lastNotify:
+      lastAttempt:
         type: string
         format: date-time
-      lastNotifyDuration:
+      lastAttemptDuration:
         type: string
-      lastError:
+      lastAttemptError:
         type: string
     required:
       - name

--- a/api/v2/openapi.yaml
+++ b/api/v2/openapi.yaml
@@ -523,15 +523,15 @@ definitions:
         type: string
       sendResolved:
         type: boolean
-      lastAttempt:
+      lastNotifyAttempt:
         description: A timestamp indicating the last attempt to deliver a notification regardless of the outcome.
         type: string
         format: date-time
-      lastAttemptDuration:
+      lastNotifyAttemptDuration:
         description: Duration of the last attempt to deliver a notification in humanized format (`1s` or `15ms`, etc).
         type: string
-      lastAttemptError:
-        description: Error string for the last attempt to deliver a notification. Empty If the last attempt was successful.
+      lastNotifyAttemptError:
+        description: Error string for the last attempt to deliver a notification. Empty if the last attempt was successful.
         type: string
     required:
       - name

--- a/api/v2/openapi.yaml
+++ b/api/v2/openapi.yaml
@@ -524,11 +524,14 @@ definitions:
       sendResolved:
         type: boolean
       lastAttempt:
+        description: A timestamp indicating the last attempt to deliver a notification regardless of the outcome.
         type: string
         format: date-time
       lastAttemptDuration:
+        description: Duration of the last attempt to deliver a notification in humanized format (`1s` or `15ms`, etc).
         type: string
       lastAttemptError:
+        description: Error string for the last attempt to deliver a notification. Empty If the last attempt was successful.
         type: string
     required:
       - name

--- a/api/v2/restapi/embedded_spec.go
+++ b/api/v2/restapi/embedded_spec.go
@@ -606,14 +606,14 @@ func init() {
         "sendResolved"
       ],
       "properties": {
-        "lastError": {
-          "type": "string"
-        },
-        "lastNotify": {
+        "lastAttempt": {
           "type": "string",
           "format": "date-time"
         },
-        "lastNotifyDuration": {
+        "lastAttemptDuration": {
+          "type": "string"
+        },
+        "lastAttemptError": {
           "type": "string"
         },
         "name": {
@@ -1456,14 +1456,14 @@ func init() {
         "sendResolved"
       ],
       "properties": {
-        "lastError": {
-          "type": "string"
-        },
-        "lastNotify": {
+        "lastAttempt": {
           "type": "string",
           "format": "date-time"
         },
-        "lastNotifyDuration": {
+        "lastAttemptDuration": {
+          "type": "string"
+        },
+        "lastAttemptError": {
           "type": "string"
         },
         "name": {

--- a/api/v2/restapi/embedded_spec.go
+++ b/api/v2/restapi/embedded_spec.go
@@ -606,17 +606,17 @@ func init() {
         "sendResolved"
       ],
       "properties": {
-        "lastAttempt": {
+        "lastNotifyAttempt": {
           "description": "A timestamp indicating the last attempt to deliver a notification regardless of the outcome.",
           "type": "string",
           "format": "date-time"
         },
-        "lastAttemptDuration": {
+        "lastNotifyAttemptDuration": {
           "description": "Duration of the last attempt to deliver a notification in humanized format (` + "`" + `1s` + "`" + ` or ` + "`" + `15ms` + "`" + `, etc).",
           "type": "string"
         },
-        "lastAttemptError": {
-          "description": "Error string for the last attempt to deliver a notification. Empty If the last attempt was successful.",
+        "lastNotifyAttemptError": {
+          "description": "Error string for the last attempt to deliver a notification. Empty if the last attempt was successful.",
           "type": "string"
         },
         "name": {
@@ -1459,17 +1459,17 @@ func init() {
         "sendResolved"
       ],
       "properties": {
-        "lastAttempt": {
+        "lastNotifyAttempt": {
           "description": "A timestamp indicating the last attempt to deliver a notification regardless of the outcome.",
           "type": "string",
           "format": "date-time"
         },
-        "lastAttemptDuration": {
+        "lastNotifyAttemptDuration": {
           "description": "Duration of the last attempt to deliver a notification in humanized format (` + "`" + `1s` + "`" + ` or ` + "`" + `15ms` + "`" + `, etc).",
           "type": "string"
         },
-        "lastAttemptError": {
-          "description": "Error string for the last attempt to deliver a notification. Empty If the last attempt was successful.",
+        "lastNotifyAttemptError": {
+          "description": "Error string for the last attempt to deliver a notification. Empty if the last attempt was successful.",
           "type": "string"
         },
         "name": {

--- a/api/v2/restapi/embedded_spec.go
+++ b/api/v2/restapi/embedded_spec.go
@@ -607,13 +607,16 @@ func init() {
       ],
       "properties": {
         "lastAttempt": {
+          "description": "A timestamp indicating the last attempt to deliver a notification regardless of the outcome.",
           "type": "string",
           "format": "date-time"
         },
         "lastAttemptDuration": {
+          "description": "Duration of the last attempt to deliver a notification in humanized format (` + "`" + `1s` + "`" + ` or ` + "`" + `15ms` + "`" + `, etc).",
           "type": "string"
         },
         "lastAttemptError": {
+          "description": "Error string for the last attempt to deliver a notification. Empty If the last attempt was successful.",
           "type": "string"
         },
         "name": {
@@ -1457,13 +1460,16 @@ func init() {
       ],
       "properties": {
         "lastAttempt": {
+          "description": "A timestamp indicating the last attempt to deliver a notification regardless of the outcome.",
           "type": "string",
           "format": "date-time"
         },
         "lastAttemptDuration": {
+          "description": "Duration of the last attempt to deliver a notification in humanized format (` + "`" + `1s` + "`" + ` or ` + "`" + `15ms` + "`" + `, etc).",
           "type": "string"
         },
         "lastAttemptError": {
+          "description": "Error string for the last attempt to deliver a notification. Empty If the last attempt was successful.",
           "type": "string"
         },
         "name": {

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -66,10 +66,10 @@ type Integration struct {
 	name     string
 	idx      int
 
-	mtx                 sync.RWMutex
-	lastAttempt         time.Time
-	lastAttemptDuration time.Duration
-	lastAttemptError    error
+	mtx                       sync.RWMutex
+	lastNotifyAttempt         time.Time
+	lastNotifyAttemptDuration time.Duration
+	lastNotifyAttemptError    error
 }
 
 // NewIntegration returns a new integration.
@@ -106,16 +106,16 @@ func (i *Integration) Report(start time.Time, duration time.Duration, notifyErro
 	i.mtx.Lock()
 	defer i.mtx.Unlock()
 
-	i.lastAttempt = start
-	i.lastAttemptDuration = duration
-	i.lastAttemptError = notifyError
+	i.lastNotifyAttempt = start
+	i.lastNotifyAttemptDuration = duration
+	i.lastNotifyAttemptError = notifyError
 }
 
 func (i *Integration) GetReport() (time.Time, time.Duration, error) {
 	i.mtx.RLock()
 	defer i.mtx.RUnlock()
 
-	return i.lastAttempt, i.lastAttemptDuration, i.lastAttemptError
+	return i.lastNotifyAttempt, i.lastNotifyAttemptDuration, i.lastNotifyAttemptError
 }
 
 // String implements the Stringer interface.

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -66,10 +66,10 @@ type Integration struct {
 	name     string
 	idx      int
 
-	mtx                sync.RWMutex
-	lastError          error
-	lastNotify         time.Time
-	lastNotifyDuration time.Duration
+	mtx                 sync.RWMutex
+	lastAttempt         time.Time
+	lastAttemptDuration time.Duration
+	lastAttemptError    error
 }
 
 // NewIntegration returns a new integration.
@@ -106,16 +106,16 @@ func (i *Integration) Report(start time.Time, duration time.Duration, notifyErro
 	i.mtx.Lock()
 	defer i.mtx.Unlock()
 
-	i.lastNotify = start
-	i.lastNotifyDuration = duration
-	i.lastError = notifyError
+	i.lastAttempt = start
+	i.lastAttemptDuration = duration
+	i.lastAttemptError = notifyError
 }
 
 func (i *Integration) GetReport() (time.Time, time.Duration, error) {
 	i.mtx.RLock()
 	defer i.mtx.RUnlock()
 
-	return i.lastNotify, i.lastNotifyDuration, i.lastError
+	return i.lastAttempt, i.lastAttemptDuration, i.lastAttemptError
 }
 
 // String implements the Stringer interface.


### PR DESCRIPTION
We're using `lastNotify` and `lastNotifyDuration` to indicate the time and duration for the last attempt regardless of the outcome. A better option would be to use `lastAttempt` and `lastAttemptDuration` instead.

The field `lastError` doesn't store the last error that occurred, but the error for the last attempt to notify (if any). This could be confusing because if a notification fails to deliver once but succeeds afterwards, this field will be empty. The name has been changed to `lastAttemptError` to better reflect this behavior.