### PR TITLE
Use Prometheus format for durations

### DIFF
--- a/notify/notify.go
+++ b/notify/notify.go
@@ -68,7 +68,7 @@ type Integration struct {
 
 	mtx                       sync.RWMutex
 	lastNotifyAttempt         time.Time
-	lastNotifyAttemptDuration time.Duration
+	lastNotifyAttemptDuration model.Duration
 	lastNotifyAttemptError    error
 }
 
@@ -102,7 +102,7 @@ func (i *Integration) Index() int {
 	return i.idx
 }
 
-func (i *Integration) Report(start time.Time, duration time.Duration, notifyError error) {
+func (i *Integration) Report(start time.Time, duration model.Duration, notifyError error) {
 	i.mtx.Lock()
 	defer i.mtx.Unlock()
 
@@ -111,7 +111,7 @@ func (i *Integration) Report(start time.Time, duration time.Duration, notifyErro
 	i.lastNotifyAttemptError = notifyError
 }
 
-func (i *Integration) GetReport() (time.Time, time.Duration, error) {
+func (i *Integration) GetReport() (time.Time, model.Duration, error) {
 	i.mtx.RLock()
 	defer i.mtx.RUnlock()
 
@@ -744,7 +744,7 @@ func (r RetryStage) exec(ctx context.Context, l log.Logger, alerts ...*types.Ale
 
 			r.metrics.notificationLatencySeconds.WithLabelValues(r.integration.Name()).Observe(duration.Seconds())
 			r.metrics.numNotificationRequestsTotal.WithLabelValues(r.integration.Name()).Inc()
-			r.integration.Report(now, duration, err)
+			r.integration.Report(now, model.Duration(duration), err)
 			if err != nil {
 				r.metrics.numNotificationRequestsFailedTotal.WithLabelValues(r.integration.Name()).Inc()
 				if !retry {


### PR DESCRIPTION
Our Receivers API is using the Go format for the `lastAttemptDuration` field. This goes against what Prometheus uses for other durations.
Excerpt from the [docs](https://prometheus.io/docs/alerting/latest/configuration/#configuration-file):

> `<duration>`: a duration matching the regular expression `((([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?|0)`, e.g. `1d`, `1h30m`, `5m`, `10s`