### PR TITLE
Fix build, regenerate openAPI

### DIFF
--- a/api/v2/models/integration.go
+++ b/api/v2/models/integration.go
@@ -20,6 +20,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
@@ -73,7 +75,6 @@ func (m *Integration) Validate(formats strfmt.Registry) error {
 }
 
 func (m *Integration) validateLastNotifyAttempt(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.LastNotifyAttempt) { // not required
 		return nil
 	}
@@ -100,6 +101,11 @@ func (m *Integration) validateSendResolved(formats strfmt.Registry) error {
 		return err
 	}
 
+	return nil
+}
+
+// ContextValidate validates this integration based on context it is used
+func (m *Integration) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 


### PR DESCRIPTION
This repo cannot be built, due to `make` running a linter - some generated code from our custom commits doesn't conform to the linter.

Regenerate it to fix the build again.