### PR TITLE
Allow the creation of silences with pre-set IDs

### DIFF
--- a/silence/silence.go
+++ b/silence/silence.go
@@ -610,6 +610,25 @@ func (s *Silences) Set(sil *pb.Silence) (string, error) {
 	return sil.Id, s.setSilence(sil, now, false)
 }
 
+// Upsert allows creating silences with a predefined ID.
+func (s *Silences) Upsert(sil *pb.Silence) (string, error) {
+	id, err := s.Set(sil)
+	if !errors.Is(err, ErrNotFound) {
+		return id, err
+	}
+
+	// If the silence was not found, create it with the given ID.
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	now := s.nowUTC()
+	if sil.StartsAt.Before(now) {
+		sil.StartsAt = now
+	}
+
+	return sil.Id, s.setSilence(sil, now, false)
+}
+
 // canUpdate returns true if silence a can be updated to b without
 // affecting the historic view of silencing.
 func canUpdate(a, b *pb.Silence, now time.Time) bool {

--- a/silence/silence.go
+++ b/silence/silence.go
@@ -573,12 +573,35 @@ func (s *Silences) setSilence(sil *pb.Silence, now time.Time, skipValidate bool)
 	return nil
 }
 
+// Upsert allows creating silences with a predefined ID.
+func (s *Silences) Upsert(sil *pb.Silence) (string, error) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	id, err := s.set(sil)
+	if !errors.Is(err, ErrNotFound) {
+		return id, err
+	}
+
+	// If the silence was not found, create it with the given ID.
+	now := s.nowUTC()
+	if sil.StartsAt.Before(now) {
+		sil.StartsAt = now
+	}
+
+	return sil.Id, s.setSilence(sil, now, false)
+}
+
 // Set the specified silence. If a silence with the ID already exists and the modification
 // modifies history, the old silence gets expired and a new one is created.
 func (s *Silences) Set(sil *pb.Silence) (string, error) {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
+	return s.set(sil)
+}
 
+// set assumes a lock is being held in the calling method.
+func (s *Silences) set(sil *pb.Silence) (string, error) {
 	now := s.nowUTC()
 	prev, ok := s.getSilence(sil.Id)
 
@@ -603,25 +626,6 @@ func (s *Silences) Set(sil *pb.Silence) (string, error) {
 	}
 	sil.Id = uid.String()
 
-	if sil.StartsAt.Before(now) {
-		sil.StartsAt = now
-	}
-
-	return sil.Id, s.setSilence(sil, now, false)
-}
-
-// Upsert allows creating silences with a predefined ID.
-func (s *Silences) Upsert(sil *pb.Silence) (string, error) {
-	id, err := s.Set(sil)
-	if !errors.Is(err, ErrNotFound) {
-		return id, err
-	}
-
-	// If the silence was not found, create it with the given ID.
-	s.mtx.Lock()
-	defer s.mtx.Unlock()
-
-	now := s.nowUTC()
 	if sil.StartsAt.Before(now) {
 		sil.StartsAt = now
 	}

--- a/silence/silence_test.go
+++ b/silence/silence_test.go
@@ -459,6 +459,50 @@ func TestSilenceSet(t *testing.T) {
 	require.Equal(t, want, s.st, "unexpected state after silence creation")
 }
 
+func TestSilenceUpsert(t *testing.T) {
+	s, err := New(Options{
+		Retention: time.Hour,
+	})
+	require.NoError(t, err)
+
+	clock := clock.NewMock()
+	s.clock = clock
+
+	// Insert silence with predefined id.
+	clock.Add(time.Minute)
+	start := s.nowUTC()
+
+	testID := "some_id"
+	sil := &pb.Silence{
+		Id:       testID,
+		Matchers: []*pb.Matcher{{Name: "a", Pattern: "b"}},
+		StartsAt: start.Add(2 * time.Minute),
+		EndsAt:   start.Add(5 * time.Minute),
+	}
+	id, err := s.Upsert(sil)
+	require.NoError(t, err)
+	require.Equal(t, testID, id)
+
+	want := state{
+		id: &pb.MeshSilence{
+			Silence: &pb.Silence{
+				Id:        testID,
+				Matchers:  []*pb.Matcher{{Name: "a", Pattern: "b"}},
+				StartsAt:  start.Add(2 * time.Minute),
+				EndsAt:    start.Add(5 * time.Minute),
+				UpdatedAt: start,
+			},
+			ExpiresAt: start.Add(5*time.Minute + s.retention),
+		},
+	}
+	require.Equal(t, want, s.st, "unexpected state after silence creation")
+
+	// Trying to insert an invalid silence should fail.
+	clock.Add(time.Minute)
+	_, err = s.Upsert(&pb.Silence{})
+	checkErr(t, "silence invalid", err)
+}
+
 func TestSetActiveSilence(t *testing.T) {
 	s, err := New(Options{
 		Retention: time.Hour,


### PR DESCRIPTION
This PR adds an `Upsert` option to `Silences.Set()` to create new silences with pre-set IDs. Instead of returning `ErrNotFound`, we create a silence using that ID. This is useful when replicating silences between the internal and remote Alertmanager (e.g. if we need to delete the same silence in both Alertmanagers).