### PR TITLE
Bring in upstream fixes to silences

### DIFF
--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -662,8 +662,7 @@ func (api *API) postSilencesHandler(params silence_ops.PostSilencesParams) middl
 		return silence_ops.NewPostSilencesBadRequest().WithPayload(msg)
 	}
 
-	sid, err := api.silences.Set(sil)
-	if err != nil {
+	if err = api.silences.Set(sil); err != nil {
 		level.Error(logger).Log("msg", "Failed to create silence", "err", err)
 		if errors.Is(err, silence.ErrNotFound) {
 			return silence_ops.NewPostSilencesNotFound().WithPayload(err.Error())
@@ -672,7 +671,7 @@ func (api *API) postSilencesHandler(params silence_ops.PostSilencesParams) middl
 	}
 
 	return silence_ops.NewPostSilencesOK().WithPayload(&silence_ops.PostSilencesOKBody{
-		SilenceID: sid,
+		SilenceID: sil.Id,
 	})
 }
 

--- a/api/v2/api_test.go
+++ b/api/v2/api_test.go
@@ -159,8 +159,7 @@ func TestDeleteSilenceHandler(t *testing.T) {
 		EndsAt:    now.Add(time.Hour),
 		UpdatedAt: now,
 	}
-	unexpiredSid, err := silences.Set(unexpiredSil)
-	require.NoError(t, err)
+	require.NoError(t, silences.Set(unexpiredSil))
 
 	expiredSil := &silencepb.Silence{
 		Matchers:  []*silencepb.Matcher{m},
@@ -168,9 +167,8 @@ func TestDeleteSilenceHandler(t *testing.T) {
 		EndsAt:    now.Add(time.Hour),
 		UpdatedAt: now,
 	}
-	expiredSid, err := silences.Set(expiredSil)
-	require.NoError(t, err)
-	require.NoError(t, silences.Expire(expiredSid))
+	require.NoError(t, silences.Set(expiredSil))
+	require.NoError(t, silences.Expire(expiredSil.Id))
 
 	for i, tc := range []struct {
 		sid          string
@@ -181,11 +179,11 @@ func TestDeleteSilenceHandler(t *testing.T) {
 			404,
 		},
 		{
-			unexpiredSid,
+			unexpiredSil.Id,
 			200,
 		},
 		{
-			expiredSid,
+			expiredSil.Id,
 			200,
 		},
 	} {
@@ -223,8 +221,7 @@ func TestPostSilencesHandler(t *testing.T) {
 		EndsAt:    now.Add(time.Hour),
 		UpdatedAt: now,
 	}
-	unexpiredSid, err := silences.Set(unexpiredSil)
-	require.NoError(t, err)
+	require.NoError(t, silences.Set(unexpiredSil))
 
 	expiredSil := &silencepb.Silence{
 		Matchers:  []*silencepb.Matcher{m},
@@ -232,9 +229,8 @@ func TestPostSilencesHandler(t *testing.T) {
 		EndsAt:    now.Add(time.Hour),
 		UpdatedAt: now,
 	}
-	expiredSid, err := silences.Set(expiredSil)
-	require.NoError(t, err)
-	require.NoError(t, silences.Expire(expiredSid))
+	require.NoError(t, silences.Set(expiredSil))
+	require.NoError(t, silences.Expire(expiredSil.Id))
 
 	t.Run("Silences CRUD", func(t *testing.T) {
 		for i, tc := range []struct {
@@ -259,14 +255,14 @@ func TestPostSilencesHandler(t *testing.T) {
 			},
 			{
 				"with an active silence ID - it extends the silence",
-				unexpiredSid,
+				unexpiredSil.Id,
 				now.Add(time.Hour),
 				now.Add(time.Hour * 2),
 				200,
 			},
 			{
 				"with an expired silence ID - it re-creates the silence",
-				expiredSid,
+				expiredSil.Id,
 				now.Add(time.Hour),
 				now.Add(time.Hour * 2),
 				200,

--- a/api/v2/testing.go
+++ b/api/v2/testing.go
@@ -14,19 +14,17 @@
 package v2
 
 import (
-	"encoding/json"
 	"testing"
 	"time"
 
 	"github.com/go-openapi/strfmt"
-	"github.com/stretchr/testify/require"
 
 	open_api_models "github.com/prometheus/alertmanager/api/v2/models"
 	"github.com/prometheus/alertmanager/pkg/labels"
 	"github.com/prometheus/alertmanager/silence/silencepb"
 )
 
-func createSilence(t *testing.T, ID, creator string, start, ends time.Time) (open_api_models.PostableSilence, []byte) {
+func createSilence(t *testing.T, ID, creator string, start, ends time.Time) open_api_models.PostableSilence {
 	t.Helper()
 
 	comment := "test"
@@ -46,10 +44,7 @@ func createSilence(t *testing.T, ID, creator string, start, ends time.Time) (ope
 			Comment:   &comment,
 		},
 	}
-	b, err := json.Marshal(&sil)
-	require.NoError(t, err)
-
-	return sil, b
+	return sil
 }
 
 func createSilenceMatcher(t *testing.T, name, pattern string, matcherType silencepb.Matcher_Type) *silencepb.Matcher {

--- a/notify/notify_test.go
+++ b/notify/notify_test.go
@@ -717,11 +717,11 @@ func TestMuteStageWithSilences(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	silID, err := silences.Set(&silencepb.Silence{
+	sil := &silencepb.Silence{
 		EndsAt:   utcNow().Add(time.Hour),
 		Matchers: []*silencepb.Matcher{{Name: "mute", Pattern: "me"}},
-	})
-	if err != nil {
+	}
+	if err = silences.Set(sil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -798,7 +798,7 @@ func TestMuteStageWithSilences(t *testing.T) {
 	}
 
 	// Expire the silence and verify that no alerts are silenced now.
-	if err := silences.Expire(silID); err != nil {
+	if err := silences.Expire(sil.Id); err != nil {
 		t.Fatal(err)
 	}
 

--- a/silence/silence.go
+++ b/silence/silence.go
@@ -601,8 +601,9 @@ func (s *Silences) Upsert(sil *pb.Silence) error {
 	if sil.StartsAt.Before(now) {
 		sil.StartsAt = now
 	}
+	sil.UpdatedAt = now
 
-	return s.setSilence(sil, now, false)
+	return s.setSilence(s.toMeshSilence(sil), now)
 }
 
 // Set the specified silence. If a silence with the ID already exists and the modification

--- a/silence/silence.go
+++ b/silence/silence.go
@@ -518,9 +518,6 @@ func matchesEmpty(m *pb.Matcher) bool {
 }
 
 func validateSilence(s *pb.Silence) error {
-	if s.Id == "" {
-		return errors.New("ID missing")
-	}
 	if len(s.Matchers) == 0 {
 		return errors.New("at least one matcher required")
 	}
@@ -543,9 +540,6 @@ func validateSilence(s *pb.Silence) error {
 	}
 	if s.EndsAt.Before(s.StartsAt) {
 		return errors.New("end time must not be before start time")
-	}
-	if s.UpdatedAt.IsZero() {
-		return errors.New("invalid zero update timestamp")
 	}
 	return nil
 }
@@ -571,14 +565,8 @@ func (s *Silences) toMeshSilence(sil *pb.Silence) *pb.MeshSilence {
 	}
 }
 
-func (s *Silences) setSilence(sil *pb.Silence, now time.Time, skipValidate bool) error {
+func (s *Silences) setSilence(sil *pb.Silence, now time.Time) error {
 	sil.UpdatedAt = now
-
-	if !skipValidate {
-		if err := validateSilence(sil); err != nil {
-			return fmt.Errorf("silence invalid: %w", err)
-		}
-	}
 
 	msil := s.toMeshSilence(sil)
 	b, err := marshalMeshSilence(msil)
@@ -633,13 +621,21 @@ func (s *Silences) Set(sil *pb.Silence) error {
 // set assumes a lock is being held in the calling method.
 func (s *Silences) set(sil *pb.Silence) error {
 	now := s.nowUTC()
+	if sil.StartsAt.IsZero() {
+		sil.StartsAt = now
+	}
+
+	if err := validateSilence(sil); err != nil {
+		return fmt.Errorf("invalid silence: %w", err)
+	}
+
 	prev, ok := s.getSilence(sil.Id)
 	if sil.Id != "" && !ok {
 		return ErrNotFound
 	}
 
 	if ok && canUpdate(prev, sil, now) {
-		return s.setSilence(sil, now, false)
+		return s.setSilence(sil, now)
 	}
 
 	// If we got here it's either a new silence or a replacing one (which would
@@ -669,7 +665,7 @@ func (s *Silences) set(sil *pb.Silence) error {
 		sil.StartsAt = now
 	}
 
-	return s.setSilence(sil, now, false)
+	return s.setSilence(sil, now)
 }
 
 // canUpdate returns true if silence a can be updated to b without
@@ -727,10 +723,7 @@ func (s *Silences) expire(id string) error {
 		sil.StartsAt = now
 		sil.EndsAt = now
 	}
-
-	// Skip validation of the silence when expiring it. Without this, silences created
-	// with valid UTF-8 matchers cannot be expired when Alertmanager is run in classic mode.
-	return s.setSilence(sil, now, true)
+	return s.setSilence(sil, now)
 }
 
 // QueryParam expresses parameters along which silences are queried.

--- a/silence/silence.go
+++ b/silence/silence.go
@@ -564,6 +564,13 @@ func (s *Silences) getSilence(id string) (*pb.Silence, bool) {
 	return msil.Silence, true
 }
 
+func (s *Silences) toMeshSilence(sil *pb.Silence) *pb.MeshSilence {
+	return &pb.MeshSilence{
+		Silence:   sil,
+		ExpiresAt: sil.EndsAt.Add(s.retention),
+	}
+}
+
 func (s *Silences) setSilence(sil *pb.Silence, now time.Time, skipValidate bool) error {
 	sil.UpdatedAt = now
 
@@ -573,10 +580,7 @@ func (s *Silences) setSilence(sil *pb.Silence, now time.Time, skipValidate bool)
 		}
 	}
 
-	msil := &pb.MeshSilence{
-		Silence:   sil,
-		ExpiresAt: sil.EndsAt.Add(s.retention),
-	}
+	msil := s.toMeshSilence(sil)
 	b, err := marshalMeshSilence(msil)
 	if err != nil {
 		return err
@@ -635,22 +639,24 @@ func (s *Silences) set(sil *pb.Silence) (string, error) {
 		return ErrNotFound
 	}
 
-	if ok {
-		if canUpdate(prev, sil, now) {
-			return s.setSilence(sil, now, false)
-		}
-		if getState(prev, s.nowUTC()) != types.SilenceStateExpired {
-			// We cannot update the silence, expire the old one.
-			if err := s.expire(prev.Id); err != nil {
-				return fmt.Errorf("expire previous silence: %w", err)
-			}
-		}
+	if ok && canUpdate(prev, sil, now) {
+		return s.setSilence(sil, now, false)
 	}
 
-	// If we got here it's either a new silence or a replacing one.
+	// If we got here it's either a new silence or a replacing one (which would
+	// also create a new silence) so we need to make sure we have capacity for
+	// the new silence.
 	if s.limits.MaxSilences != nil {
 		if m := s.limits.MaxSilences(); m > 0 && len(s.st)+1 > m {
 			return fmt.Errorf("exceeded maximum number of silences: %d (limit: %d)", len(s.st), m)
+		}
+	}
+
+	if ok && getState(prev, s.nowUTC()) != types.SilenceStateExpired {
+		// We cannot update the silence, expire the old one to leave a history of
+		// the silence before modification.
+		if err := s.expire(prev.Id); err != nil {
+			return fmt.Errorf("expire previous silence: %w", err)
 		}
 	}
 

--- a/silence/silence_bench_test.go
+++ b/silence/silence_bench_test.go
@@ -58,8 +58,7 @@ func benchmarkMutes(b *testing.B, n int) {
 
 	var silenceIDs []string
 	for i := 0; i < n; i++ {
-		var silenceID string
-		silenceID, err = silences.Set(&silencepb.Silence{
+		s := &silencepb.Silence{
 			Matchers: []*silencepb.Matcher{{
 				Type:    silencepb.Matcher_EQUAL,
 				Name:    "foo",
@@ -67,9 +66,10 @@ func benchmarkMutes(b *testing.B, n int) {
 			}},
 			StartsAt: now,
 			EndsAt:   now.Add(time.Minute),
-		})
+		}
+		require.NoError(b, silences.Set(s))
 		require.NoError(b, err)
-		silenceIDs = append(silenceIDs, silenceID)
+		silenceIDs = append(silenceIDs, s.Id)
 	}
 	require.Len(b, silenceIDs, n)
 

--- a/silence/silence_test.go
+++ b/silence/silence_test.go
@@ -295,7 +295,7 @@ func TestSilencesSetSilence(t *testing.T) {
 	func() {
 		s.mtx.Lock()
 		defer s.mtx.Unlock()
-		require.NoError(t, s.setSilence(sil, nowpb, false))
+		require.NoError(t, s.setSilence(sil, nowpb))
 	}()
 
 	// Ensure broadcast was called.
@@ -468,6 +468,19 @@ func TestSilenceSet(t *testing.T) {
 		},
 	}
 	require.Equal(t, want, s.st, "unexpected state after silence creation")
+
+	// Updating an existing silence with an invalid silence should not expire
+	// the original silence.
+	clock.Add(time.Millisecond)
+	sil8 := cloneSilence(sil7)
+	sil8.EndsAt = time.Time{}
+	require.EqualError(t, s.Set(sil8), "invalid silence: invalid zero end timestamp")
+
+	// sil7 should not be expired because the update failed.
+	clock.Add(time.Millisecond)
+	sil7, err = s.QueryOne(QIDs(sil7.Id))
+	require.NoError(t, err)
+	require.Equal(t, types.SilenceStateActive, getState(sil7, s.nowUTC()))
 }
 
 func TestSilenceLimits(t *testing.T) {
@@ -685,11 +698,15 @@ func TestSilencesSetFail(t *testing.T) {
 		err string
 	}{
 		{
-			s:   &pb.Silence{Id: "some_id"},
+			s: &pb.Silence{
+				Id:       "some_id",
+				Matchers: []*pb.Matcher{{Name: "a", Pattern: "b"}},
+				EndsAt:   clock.Now().Add(5 * time.Minute),
+			},
 			err: ErrNotFound.Error(),
 		}, {
 			s:   &pb.Silence{}, // Silence without matcher.
-			err: "silence invalid",
+			err: "invalid silence",
 		},
 	}
 	for _, c := range cases {
@@ -1532,18 +1549,6 @@ func TestValidateSilence(t *testing.T) {
 		},
 		{
 			s: &pb.Silence{
-				Id: "",
-				Matchers: []*pb.Matcher{
-					{Name: "a", Pattern: "b"},
-				},
-				StartsAt:  validTimestamp,
-				EndsAt:    validTimestamp,
-				UpdatedAt: validTimestamp,
-			},
-			err: "ID missing",
-		},
-		{
-			s: &pb.Silence{
 				Id:        "some_id",
 				Matchers:  []*pb.Matcher{},
 				StartsAt:  validTimestamp,
@@ -1613,18 +1618,6 @@ func TestValidateSilence(t *testing.T) {
 				UpdatedAt: validTimestamp,
 			},
 			err: "invalid zero end timestamp",
-		},
-		{
-			s: &pb.Silence{
-				Id: "some_id",
-				Matchers: []*pb.Matcher{
-					{Name: "a", Pattern: "b"},
-				},
-				StartsAt:  validTimestamp,
-				EndsAt:    validTimestamp,
-				UpdatedAt: zeroTimestamp,
-			},
-			err: "invalid zero update timestamp",
 		},
 	}
 	for _, c := range cases {

--- a/silence/silence_test.go
+++ b/silence/silence_test.go
@@ -15,6 +15,7 @@ package silence
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"runtime"
 	"sort"
@@ -470,32 +471,24 @@ func TestSilenceLimits(t *testing.T) {
 		EndsAt:   time.Now().Add(5 * time.Minute),
 	}
 	require.NoError(t, s.Set(sil1))
-	require.NotEqual(t, "", sil1.Id)
 
-	// Insert sil2 should fail because maximum number of silences
-	// has been exceeded.
+	// Insert sil2 should fail because maximum number of silences has been
+	// exceeded.
 	sil2 := &pb.Silence{
-		Matchers: []*pb.Matcher{{Name: "a", Pattern: "b"}},
+		Matchers: []*pb.Matcher{{Name: "c", Pattern: "d"}},
 		StartsAt: time.Now(),
 		EndsAt:   time.Now().Add(5 * time.Minute),
 	}
 	require.EqualError(t, s.Set(sil2), "exceeded maximum number of silences: 1 (limit: 1)")
-	require.Equal(t, "", sil2.Id)
 
-	// Expire sil1 and run the GC. This should allow sil2 to be
-	// inserted.
+	// Expire sil1 and run the GC. This should allow sil2 to be inserted.
 	require.NoError(t, s.Expire(sil1.Id))
 	n, err := s.GC()
 	require.NoError(t, err)
 	require.Equal(t, 1, n)
-
-	require.NoError(t, s.Set(sil2))
-	require.NotEqual(t, "", sil2.Id)
-
-	// Should be able to update sil2 without hitting the limit.
 	require.NoError(t, s.Set(sil2))
 
-	// Expire sil2.
+	// Expire sil2 and run the GC.
 	require.NoError(t, s.Expire(sil2.Id))
 	n, err = s.GC()
 	require.NoError(t, err)
@@ -505,26 +498,55 @@ func TestSilenceLimits(t *testing.T) {
 	sil3 := &pb.Silence{
 		Matchers: []*pb.Matcher{
 			{
-				Name:    strings.Repeat("a", 2<<9),
-				Pattern: strings.Repeat("b", 2<<9),
+				Name:    strings.Repeat("e", 2<<9),
+				Pattern: strings.Repeat("f", 2<<9),
 			},
 			{
-				Name:    strings.Repeat("c", 2<<9),
-				Pattern: strings.Repeat("d", 2<<9),
+				Name:    strings.Repeat("g", 2<<9),
+				Pattern: strings.Repeat("h", 2<<9),
 			},
 		},
-		CreatedBy: strings.Repeat("e", 2<<9),
-		Comment:   strings.Repeat("f", 2<<9),
+		CreatedBy: strings.Repeat("i", 2<<9),
+		Comment:   strings.Repeat("j", 2<<9),
 		StartsAt:  time.Now(),
 		EndsAt:    time.Now().Add(5 * time.Minute),
 	}
-	err = s.Set(sil3)
-	require.Error(t, err)
-	// Do not check the exact size as it can change between consecutive runs
-	// due to padding.
-	require.Contains(t, err.Error(), "silence exceeded maximum size")
-	// TODO: Once we fix https://github.com/prometheus/alertmanager/issues/3878 this should be require.Equal.
-	require.NotEqual(t, "", sil3.Id)
+	require.EqualError(t, s.Set(sil3), fmt.Sprintf("silence exceeded maximum size: %d bytes (limit: 4096 bytes)", s.toMeshSilence(sil3).Size()))
+
+	// Should be able to insert sil4.
+	sil4 := &pb.Silence{
+		Matchers: []*pb.Matcher{{Name: "k", Pattern: "l"}},
+		StartsAt: time.Now(),
+		EndsAt:   time.Now().Add(5 * time.Minute),
+	}
+	require.NoError(t, s.Set(sil4))
+
+	// Should be able to update sil4 without modifications. It is expected to
+	// keep the same ID.
+	sil5 := cloneSilence(sil4)
+	require.NoError(t, s.Set(sil5))
+	require.Equal(t, sil4.Id, sil5.Id)
+
+	// Should be able to update the comment. It is also expected to keep the
+	// same ID.
+	sil6 := cloneSilence(sil5)
+	sil6.Comment = "m"
+	require.NoError(t, s.Set(sil6))
+	require.Equal(t, sil5.Id, sil6.Id)
+
+	// Should not be able to update the start and end time as this requires
+	// sil6 to be expired and a new silence to be created. However, this would
+	// exceed the maximum number of silences, which counts both active and
+	// expired silences.
+	sil7 := cloneSilence(sil6)
+	sil7.StartsAt = time.Now().Add(5 * time.Minute)
+	sil7.EndsAt = time.Now().Add(10 * time.Minute)
+	require.EqualError(t, s.Set(sil7), "exceeded maximum number of silences: 1 (limit: 1)")
+
+	// sil6 should not be expired because the update failed.
+	sil6, err = s.QueryOne(QIDs(sil6.Id))
+	require.NoError(t, err)
+	require.Equal(t, types.SilenceStateActive, getState(sil6, s.nowUTC()))
 }
 
 func TestSilenceNoLimits(t *testing.T) {

--- a/silence/silence_test.go
+++ b/silence/silence_test.go
@@ -660,7 +660,7 @@ func TestSilenceUpsert(t *testing.T) {
 
 	// Trying to insert an invalid silence should fail.
 	clock.Add(time.Minute)
-	checkErr(t, "silence invalid", s.Upsert(&pb.Silence{}))
+	checkErr(t, "invalid silence", s.Upsert(&pb.Silence{}))
 }
 
 func TestSetActiveSilence(t *testing.T) {

--- a/silence/silence_test.go
+++ b/silence/silence_test.go
@@ -601,12 +601,11 @@ func TestSilenceUpsert(t *testing.T) {
 		StartsAt: start.Add(2 * time.Minute),
 		EndsAt:   start.Add(5 * time.Minute),
 	}
-	id, err := s.Upsert(sil)
-	require.NoError(t, err)
-	require.Equal(t, testID, id)
+	require.NoError(t, s.Upsert(sil))
+	require.Equal(t, testID, sil.Id)
 
 	want := state{
-		id: &pb.MeshSilence{
+		sil.Id: &pb.MeshSilence{
 			Silence: &pb.Silence{
 				Id:        testID,
 				Matchers:  []*pb.Matcher{{Name: "a", Pattern: "b"}},
@@ -621,8 +620,7 @@ func TestSilenceUpsert(t *testing.T) {
 
 	// Trying to insert an invalid silence should fail.
 	clock.Add(time.Minute)
-	_, err = s.Upsert(&pb.Silence{})
-	checkErr(t, "silence invalid", err)
+	checkErr(t, "silence invalid", s.Upsert(&pb.Silence{}))
 }
 
 func TestSetActiveSilence(t *testing.T) {

--- a/test/with_api_v2/acceptance/utf8_test.go
+++ b/test/with_api_v2/acceptance/utf8_test.go
@@ -267,7 +267,7 @@ receivers:
 
 	_, err := am.Client().Silence.PostSilences(silenceParams)
 	require.Error(t, err)
-	require.True(t, strings.Contains(err.Error(), "silence invalid: invalid label matcher"))
+	require.True(t, strings.Contains(err.Error(), "invalid silence: invalid label matcher"))
 }
 
 func TestSendAlertsToUTF8Route(t *testing.T) {


### PR DESCRIPTION
This pull request brings in a number of upstream fixes to silences:

- https://github.com/prometheus/alertmanager/pull/3881
- https://github.com/prometheus/alertmanager/pull/3877
- https://github.com/prometheus/alertmanager/pull/3896
- https://github.com/prometheus/alertmanager/pull/3899
- https://github.com/prometheus/alertmanager/pull/3898
- https://github.com/prometheus/alertmanager/pull/3897

There are two commits which are not picked from upstream, these are:

- https://github.com/grafana/prometheus-alertmanager/pull/88/commits/b43b86c6e45d3231f26ad954dea292fe8207a18b

    We changed the behavior of `Set(sil *pb.Silence) (string, error)` to just `Set(sil *pb.Silence) error` as the additional string return value was redundant. The id is assigned to `sil`, and does not need to be returned. I have updated `Upsert` to do the same.

- https://github.com/grafana/prometheus-alertmanager/pull/88/commits/700c04ea812b4677628c653c1f4379bda788d0b1

    `Upsert` must also set the `UpdatedAt` timestamp before calling `setSilence` as this code was removed from `setSilence`, and it must also change the silence into a `*pb.MeshSilence` before calling `setSilence` as it now expects a `*pb.MeshSilence` instead of `*pb.Silence`. The bool to `setSilence` was removed as validation no longer happens in `setSilence`.