### PR TITLE
Fix panic during metrics registration

### DIFF
--- a/api/metrics/metrics_test.go
+++ b/api/metrics/metrics_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func Test_NewAlerts(t *testing.T) {
-	t.Run("metrics are registered and collected successfuly despite being registered previously", func(t *testing.T) {
+	t.Run("metrics are registered and collected successfully despite being registered previously", func(t *testing.T) {
 		r := prometheus.NewRegistry()
 		l := log.NewNopLogger()
 

--- a/api/metrics/metrics_test.go
+++ b/api/metrics/metrics_test.go
@@ -1,0 +1,47 @@
+// Copyright 2019 Prometheus Team
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/go-kit/log"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func Test_NewAlerts(t *testing.T) {
+	t.Run("metrics are registered and collected successfuly despite being registered previously", func(t *testing.T) {
+		r := prometheus.NewRegistry()
+		l := log.NewNopLogger()
+
+		require.NotPanics(t, func() {
+			for i := 0; i < 3; i++ {
+				as := NewAlerts(r, l)
+				as.Firing().Inc()
+				as.Resolved().Inc()
+				as.Invalid().Inc()
+
+				mf, err := r.Gather()
+				require.NoError(t, err)
+
+				for j := 0; j < len(mf); j++ {
+					require.Equal(t, float64(1), mf[j].GetMetric()[0].GetCounter().GetValue())
+				}
+			}
+		})
+	})
+}

--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -100,7 +100,7 @@ func NewAPI(
 		peer:           peer,
 		silences:       silences,
 		logger:         l,
-		m:              metrics.NewAlerts(r),
+		m:              metrics.NewAlerts(r, l),
 		uptime:         time.Now(),
 	}
 


### PR DESCRIPTION
Should fix https://github.com/grafana/grafana/issues/92707

We have fixed this before for the grafana metrics (https://github.com/grafana/grafana/pull/92725/files), but missed prometheus AM metrics.