### PR TITLE
Tracing: use events for http client detail

### DIFF
--- a/tracing/http.go
+++ b/tracing/http.go
@@ -30,7 +30,7 @@ import (
 func Transport(rt http.RoundTripper, name string) http.RoundTripper {
 	rt = otelhttp.NewTransport(rt,
 		otelhttp.WithClientTrace(func(ctx context.Context) *httptrace.ClientTrace {
-			return otelhttptrace.NewClientTrace(ctx)
+			return otelhttptrace.NewClientTrace(ctx, otelhttptrace.WithoutSubSpans())
 		}),
 		otelhttp.WithSpanNameFormatter(func(_ string, r *http.Request) string {
 			return name + "/HTTP " + r.Method


### PR DESCRIPTION
otelhttptrace shows the time to do DNS, get a connection, etc. By default it does these as sub-spans, but I think it's better to do them as events. Smaller volume of data and easier to view on screen.

Example with subspans:
![image](https://github.com/user-attachments/assets/38f98a43-6032-49f5-a1f9-efb8424265b4)

Example without subspans:
![image](https://github.com/user-attachments/assets/21fec0d3-77c3-40a3-a2c1-478c37849e92)
