### PR TITLE
Add tick time to dispatch logs

### DIFF
--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -560,13 +560,13 @@ func (ag *aggrGroup) flush(ctx context.Context, nf notifyFunc) {
 	tickTime, _ := notify.Now(ctx)
 	l := log.With(ag.logger, "tickTime", tickTime)
 
-	if notify(alertsSlice...) {
+	if nf(ctx, alertsSlice...) {
 		// Delete all resolved alerts as we just sent a notification for them,
 		// and we don't want to send another one. However, we need to make sure
 		// that each resolved alert has not fired again during the flush as then
 		// we would delete an active alert thinking it was resolved.
 		if err := ag.alerts.DeleteIfNotModified(resolvedSlice); err != nil {
-			level.Error(ag.logger).Log("msg", "error on delete alerts", "err", err)
+			level.Error(l).Log("msg", "error on delete alerts", "err", err)
 		}
 	}
 }

--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -560,6 +560,8 @@ func (ag *aggrGroup) flush(ctx context.Context, nf notifyFunc) {
 	tickTime, _ := notify.Now(ctx)
 	l := log.With(ag.logger, "tickTime", tickTime)
 
+	level.Debug(l).Log("msg", "flushing", "alerts", fmt.Sprintf("%v", alertsSlice))
+
 	if nf(ctx, alertsSlice...) {
 		// Delete all resolved alerts as we just sent a notification for them,
 		// and we don't want to send another one. However, we need to make sure

--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -378,8 +378,8 @@ func (d *Dispatcher) processAlert(dispatchLink trace.Link, alert *types.Alert, r
 		)
 		defer span.End()
 
-		tickTime, _ := notify.Now(ctx)
-		l := log.With(d.logger, "tickTime", tickTime)
+		pipelineTime, _ := notify.Now(ctx)
+		l := log.With(d.logger, "pipeline_time", pipelineTime)
 
 		_, _, err := d.stage.Exec(ctx, l, alerts...)
 		if err != nil {
@@ -557,8 +557,8 @@ func (ag *aggrGroup) flush(ctx context.Context, nf notifyFunc) {
 	}
 	sort.Stable(alertsSlice)
 
-	tickTime, _ := notify.Now(ctx)
-	l := log.With(ag.logger, "tickTime", tickTime)
+	pipelineTime, _ := notify.Now(ctx)
+	l := log.With(ag.logger, "pipeline_time", pipelineTime)
 
 	level.Debug(l).Log("msg", "flushing", "alerts", fmt.Sprintf("%v", alertsSlice))
 

--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -378,14 +378,17 @@ func (d *Dispatcher) processAlert(dispatchLink trace.Link, alert *types.Alert, r
 		)
 		defer span.End()
 
-		_, _, err := d.stage.Exec(ctx, d.logger, alerts...)
+		tickTime, _ := notify.Now(ctx)
+		l := log.With(d.logger, "tickTime", tickTime)
+
+		_, _, err := d.stage.Exec(ctx, l, alerts...)
 		if err != nil {
-			lvl := level.Error(d.logger)
+			lvl := level.Error(l)
 			if errors.Is(ctx.Err(), context.Canceled) {
 				// It is expected for the context to be canceled on
 				// configuration reload or shutdown. In this case, the
 				// message should only be logged at the debug level.
-				lvl = level.Debug(d.logger)
+				lvl = level.Debug(l)
 			}
 			lvl.Log("msg", "Notify for alerts failed", "num_alerts", len(alerts), "err", err)
 
@@ -494,9 +497,7 @@ func (ag *aggrGroup) run(nf notifyFunc) {
 			ag.hasFlushed = true
 			ag.mtx.Unlock()
 
-			ag.flush(func(alerts ...*types.Alert) bool {
-				return nf(ctx, alerts...)
-			})
+			ag.flush(ctx, nf)
 
 			cancel()
 
@@ -533,7 +534,7 @@ func (ag *aggrGroup) empty() bool {
 }
 
 // flush sends notifications for all new alerts.
-func (ag *aggrGroup) flush(notify func(...*types.Alert) bool) {
+func (ag *aggrGroup) flush(ctx context.Context, nf notifyFunc) {
 	if ag.empty() {
 		return
 	}
@@ -556,7 +557,8 @@ func (ag *aggrGroup) flush(notify func(...*types.Alert) bool) {
 	}
 	sort.Stable(alertsSlice)
 
-	level.Debug(ag.logger).Log("msg", "flushing", "alerts", fmt.Sprintf("%v", alertsSlice))
+	tickTime, _ := notify.Now(ctx)
+	l := log.With(ag.logger, "tickTime", tickTime)
 
 	if notify(alertsSlice...) {
 		// Delete all resolved alerts as we just sent a notification for them,


### PR DESCRIPTION
## Context
- As part of the flaky notifications investigation, it was argued that we should be able to correlate logs to a specific flush pipeline
- We inject the time of the ticker in the context before flushing the alert, adding it to the logs is easy and allows us to do exactly that