### PR TITLE
Fix DedupStage to stop pipeline if entry timestamp is from the future

### DIFF
--- a/notify/notify_test.go
+++ b/notify/notify_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	prom_testutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/common/model"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/alertmanager/featurecontrol"
@@ -221,7 +220,7 @@ func TestDedupStageNeedsUpdate(t *testing.T) {
 		res, reason := s.needsUpdate(c.entry, c.firingAlerts, c.resolvedAlerts, c.repeat)
 		require.Equal(t, c.res, res)
 		if res {
-			assert.Equal(t, c.reason, reason)
+			require.Equal(t, c.reason, reason)
 		}
 	}
 }

--- a/notify/notify_test.go
+++ b/notify/notify_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	prom_testutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/alertmanager/featurecontrol"
@@ -99,13 +100,14 @@ func TestDedupStageNeedsUpdate(t *testing.T) {
 		repeat         time.Duration
 		resolve        bool
 
-		res bool
+		res    bool
 	}{
 		{
 			// No matching nflog entry should update.
 			entry:        nil,
 			firingAlerts: alertHashSet(2, 3, 4),
 			res:          true,
+			reason:       "fire",
 		}, {
 			// No matching nflog entry shouldn't update if no alert fires.
 			entry:          nil,
@@ -116,6 +118,7 @@ func TestDedupStageNeedsUpdate(t *testing.T) {
 			entry:        &nflogpb.Entry{FiringAlerts: []uint64{1, 2, 3}},
 			firingAlerts: alertHashSet(2, 3, 4),
 			res:          true,
+			reason:       "fire subset",
 		}, {
 			// Zero timestamp in the nflog entry should always update.
 			entry: &nflogpb.Entry{
@@ -124,6 +127,7 @@ func TestDedupStageNeedsUpdate(t *testing.T) {
 			},
 			firingAlerts: alertHashSet(1, 2, 3),
 			res:          true,
+			reason:       "repeat",
 		}, {
 			// Identical sets of alerts shouldn't update before repeat_interval.
 			entry: &nflogpb.Entry{
@@ -142,6 +146,7 @@ func TestDedupStageNeedsUpdate(t *testing.T) {
 			repeat:       10 * time.Minute,
 			firingAlerts: alertHashSet(1, 2, 3),
 			res:          true,
+			reason:       "repeat",
 		}, {
 			// Different sets of resolved alerts without firing alerts shouldn't update after repeat_interval.
 			entry: &nflogpb.Entry{
@@ -176,6 +181,7 @@ func TestDedupStageNeedsUpdate(t *testing.T) {
 			resolvedAlerts: alertHashSet(2, 3),
 			resolve:        true,
 			res:            true,
+			reason:         "resolve subset",
 		}, {
 			// Empty set of firing alerts should update when resolve is false.
 			entry: &nflogpb.Entry{
@@ -188,6 +194,7 @@ func TestDedupStageNeedsUpdate(t *testing.T) {
 			resolvedAlerts: alertHashSet(1, 2, 3),
 			resolve:        false,
 			res:            true,
+			reason:         "resolve",
 		}, {
 			// Empty set of firing alerts should update when resolve is true.
 			entry: &nflogpb.Entry{
@@ -200,6 +207,7 @@ func TestDedupStageNeedsUpdate(t *testing.T) {
 			resolvedAlerts: alertHashSet(1, 2, 3),
 			resolve:        true,
 			res:            true,
+			reason:         "resolve",
 		},
 	}
 	for i, c := range cases {
@@ -209,8 +217,11 @@ func TestDedupStageNeedsUpdate(t *testing.T) {
 			now: func() time.Time { return now },
 			rs:  sendResolved(c.resolve),
 		}
-		res := s.needsUpdate(c.entry, c.firingAlerts, c.resolvedAlerts, c.repeat)
+		res, reason := s.needsUpdate(c.entry, c.firingAlerts, c.resolvedAlerts, c.repeat)
 		require.Equal(t, c.res, res)
+		if res {
+			assert.Equal(t, c.reason, reason)
+		}
 	}
 }
 

--- a/notify/notify_test.go
+++ b/notify/notify_test.go
@@ -101,6 +101,7 @@ func TestDedupStageNeedsUpdate(t *testing.T) {
 		resolve        bool
 
 		res    bool
+		reason string
 	}{
 		{
 			// No matching nflog entry should update.
@@ -237,10 +238,14 @@ func TestDedupStage(t *testing.T) {
 		now: func() time.Time {
 			return now
 		},
+		recv: &nflogpb.Receiver{
+			GroupName:   "test-receiver",
+			Integration: "test-integration",
+		},
 		rs: sendResolved(false),
 	}
 
-	ctx := context.Background()
+	ctx := WithNow(context.Background(), now)
 
 	_, _, err := s.Exec(ctx, log.NewNopLogger())
 	require.EqualError(t, err, "group key missing")
@@ -308,6 +313,20 @@ func TestDedupStage(t *testing.T) {
 	_, res, err = s.Exec(ctx, log.NewNopLogger(), alerts...)
 	require.NoError(t, err)
 	require.Equal(t, alerts, res, "unexpected alerts returned")
+
+	// Must return no error and no alerts if notification log entry is from the future
+	s.nflog = &testNflog{
+		qerr: nil,
+		qres: []*nflogpb.Entry{
+			{
+				FiringAlerts: []uint64{1, 2, 3, 4},
+				Timestamp:    now.Add(1 * time.Millisecond),
+			},
+		},
+	}
+	_, res, err = s.Exec(ctx, log.NewNopLogger(), alerts...)
+	require.NoError(t, err)
+	require.Nil(t, res)
 }
 
 func TestMultiStage(t *testing.T) {


### PR DESCRIPTION
### What this change does? 
Two things:
- updates the DedupStage to log the reason of notification. The stage emits debug log with the following labels
   -  "msg=Need to notify" 
   - "reason = ["fire"|"fire subset"|"resolve"|"resolve subset"|"repeat"]
- fixes DedupStage to behave correctly when the nflog entry's timestamp is greater than the time when the current instance flushed the pipeline. This means that there was another instance that flushed and finished the pipeline while the current instance was put on hold by `WaitStage`.  In this case, the instance will emit warning message `Timestamp of notification log entry is after the current pipeline timestamp.` and stop the pipeline if the method `needsUpdated` returned positive result.

This PR moves functionality from https://github.com/grafana/alerting/pull/268 upstream.  After several weeks in production, we could not find any false negative situations. In the opposite, this change drastically reduced number of flapping notifications for one of the customers that is run in pretty volatile environment where instances start and stop frequently.

Related https://github.com/prometheus/alertmanager/pull/3283

### Why we need this?
The debug log will improve visibility of decision making and help administrators troubleshoot the notifications better.
The fix will prevent flapping alerts when the first instance in the cluster ring, which does not stop on `WaitStage` at all, sends either firing or resolved notification and then an instance that holds the outdated alerts in the pipeline will notify user about the opposite, which will trigger the first instance to notify user again.

