### PR TITLE
Fix UTF-8 not allowed in Equal field for inhibition rules

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -882,7 +882,7 @@ type InhibitRule struct {
 	TargetMatchers Matchers `yaml:"target_matchers,omitempty" json:"target_matchers,omitempty"`
 	// A set of labels that must be equal between the source and target alert
 	// for them to be a match.
-	Equal model.LabelNames `yaml:"equal,omitempty" json:"equal,omitempty"`
+	Equal []string `yaml:"equal,omitempty" json:"equal,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface for InhibitRule.
@@ -901,6 +901,13 @@ func (r *InhibitRule) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	for k := range r.TargetMatch {
 		if !model.LabelNameRE.MatchString(k) {
 			return fmt.Errorf("invalid label name %q", k)
+		}
+	}
+
+	for _, l := range r.Equal {
+		labelName := model.LabelName(l)
+		if !compat.IsValidLabelName(labelName) {
+			return fmt.Errorf("invalid label name %q in equal list", l)
 		}
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -23,10 +23,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/log"
 	commoncfg "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
+
+	"github.com/prometheus/alertmanager/featurecontrol"
+	"github.com/prometheus/alertmanager/matchers/compat"
 )
 
 func TestLoadEmptyString(t *testing.T) {
@@ -1276,4 +1280,46 @@ func TestNilRegexp(t *testing.T) {
 			require.Contains(t, err.Error(), tc.errMsg)
 		})
 	}
+}
+
+func TestInhibitRuleEqual(t *testing.T) {
+	c, err := LoadFile("testdata/conf.inhibit-equal.yml")
+	require.NoError(t, err)
+
+	// The inhibition rule should have the expected equal labels.
+	require.Len(t, c.InhibitRules, 1)
+	r := c.InhibitRules[0]
+	require.Equal(t, []string{"qux", "corge"}, r.Equal)
+
+	// Should not be able to load configuration with UTF-8 in equals list.
+	_, err = LoadFile("testdata/conf.inhibit-equal-utf8.yml")
+	require.Error(t, err)
+	require.Equal(t, "invalid label name \"qux🙂\" in equal list", err.Error())
+
+	// Change the mode to UTF-8 mode.
+	ff, err := featurecontrol.NewFlags(log.NewNopLogger(), featurecontrol.FeatureUTF8StrictMode)
+	require.NoError(t, err)
+	compat.InitFromFlags(log.NewNopLogger(), ff)
+
+	// Restore the mode to classic at the end of the test.
+	ff, err = featurecontrol.NewFlags(log.NewNopLogger(), featurecontrol.FeatureClassicMode)
+	require.NoError(t, err)
+	defer compat.InitFromFlags(log.NewNopLogger(), ff)
+
+	c, err = LoadFile("testdata/conf.inhibit-equal.yml")
+	require.NoError(t, err)
+
+	// The inhibition rule should have the expected equal labels.
+	require.Len(t, c.InhibitRules, 1)
+	r = c.InhibitRules[0]
+	require.Equal(t, []string{"qux", "corge"}, r.Equal)
+
+	// Should also be able to load configuration with UTF-8 in equals list.
+	c, err = LoadFile("testdata/conf.inhibit-equal-utf8.yml")
+	require.NoError(t, err)
+
+	// The inhibition rule should have the expected equal labels.
+	require.Len(t, c.InhibitRules, 1)
+	r = c.InhibitRules[0]
+	require.Equal(t, []string{"qux🙂", "corge"}, r.Equal)
 }

--- a/config/testdata/conf.inhibit-equal-utf8.yml
+++ b/config/testdata/conf.inhibit-equal-utf8.yml
@@ -1,0 +1,10 @@
+route:
+  receiver: test
+receivers:
+  - name: test
+inhibit_rules:
+  - source_matchers:
+      - foo=bar
+    target_matchers:
+      - bar=baz
+    equal: ['qux🙂', 'corge']

--- a/config/testdata/conf.inhibit-equal.yml
+++ b/config/testdata/conf.inhibit-equal.yml
@@ -1,0 +1,10 @@
+route:
+  receiver: test
+receivers:
+  - name: test
+inhibit_rules:
+  - source_matchers:
+      - foo=bar
+    target_matchers:
+      - bar=baz
+    equal: ['qux', 'corge']

--- a/inhibit/inhibit.go
+++ b/inhibit/inhibit.go
@@ -215,7 +215,7 @@ func NewInhibitRule(cr config.InhibitRule) *InhibitRule {
 
 	equal := map[model.LabelName]struct{}{}
 	for _, ln := range cr.Equal {
-		equal[ln] = struct{}{}
+		equal[model.LabelName(ln)] = struct{}{}
 	}
 
 	return &InhibitRule{

--- a/inhibit/inhibit_test.go
+++ b/inhibit/inhibit_test.go
@@ -144,12 +144,12 @@ func TestInhibitRuleMatches(t *testing.T) {
 	rule1 := config.InhibitRule{
 		SourceMatch: map[string]string{"s1": "1"},
 		TargetMatch: map[string]string{"t1": "1"},
-		Equal:       model.LabelNames{"e"},
+		Equal:       []string{"e"},
 	}
 	rule2 := config.InhibitRule{
 		SourceMatch: map[string]string{"s2": "1"},
 		TargetMatch: map[string]string{"t2": "1"},
-		Equal:       model.LabelNames{"e"},
+		Equal:       []string{"e"},
 	}
 
 	m := types.NewMarker(prometheus.NewRegistry())
@@ -240,12 +240,12 @@ func TestInhibitRuleMatchers(t *testing.T) {
 	rule1 := config.InhibitRule{
 		SourceMatchers: config.Matchers{&labels.Matcher{Type: labels.MatchEqual, Name: "s1", Value: "1"}},
 		TargetMatchers: config.Matchers{&labels.Matcher{Type: labels.MatchNotEqual, Name: "t1", Value: "1"}},
-		Equal:          model.LabelNames{"e"},
+		Equal:          []string{"e"},
 	}
 	rule2 := config.InhibitRule{
 		SourceMatchers: config.Matchers{&labels.Matcher{Type: labels.MatchEqual, Name: "s2", Value: "1"}},
 		TargetMatchers: config.Matchers{&labels.Matcher{Type: labels.MatchEqual, Name: "t2", Value: "1"}},
-		Equal:          model.LabelNames{"e"},
+		Equal:          []string{"e"},
 	}
 
 	m := types.NewMarker(prometheus.NewRegistry())
@@ -374,7 +374,7 @@ func TestInhibit(t *testing.T) {
 		return config.InhibitRule{
 			SourceMatch: map[string]string{"s": "1"},
 			TargetMatch: map[string]string{"t": "1"},
-			Equal:       model.LabelNames{"e"},
+			Equal:       []string{"e"},
 		}
 	}
 	// alertOne is muted by alertTwo when it is active.


### PR DESCRIPTION
This is the second attempt to bring a fix for UTF-8 characters not allowed in the Equals field of inhibition rules into the fork. The first attempt https://github.com/grafana/prometheus-alertmanager/pull/94 (which cherry picks https://github.com/prometheus/alertmanager/pull/4177) had a subtle bug where code that would `json.Marshal` a `config.InhibitRule` could erase the `equals` field in the JSON. To prevent this from happening, but still support UTF-8, we decided to change it from `model.LabelNames` to `[]string`. This pull request cherry picks the fix from upstream (https://github.com/prometheus/alertmanager/pull/4292).

---

Here is the description from the upstream change:

This commit fixes a subtle bug introduced in #4177 where external code that imports config.InhibitRule for the purpose of JSON/YAML encoding can encode an inhibition rule with missing equals labels. This bug will happen if someone updates their Go modules, writes labels to the Equal field, and does not also write the same labels to the EqualStr field.

To fix this, I propose removing EqualStr and changing Equal from model.LabelNames to []string. This will cause an intentional breaking change, and require the maintainer of downstream code to use []string instead of model.LabelNames. I consider this a better option to the subtle bug explained earlier.

This still keeps the fix for #4177, but does so with an explicit breaking change to downstream users.