### PR TITLE
Log alerts when notification fails

### DIFF
--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -390,7 +390,7 @@ func (d *Dispatcher) processAlert(dispatchLink trace.Link, alert *types.Alert, r
 				// message should only be logged at the debug level.
 				lvl = level.Debug(l)
 			} else {
-				lvl = log.With(lvl, "alerts", fmt.Sprintf("%v", alerts))
+				lvl = log.With(lvl, "aggrGroup", ag, "alerts", fmt.Sprintf("%v", alerts))
 			}
 			lvl.Log("msg", "Notify for alerts failed", "num_alerts", len(alerts), "err", err)
 

--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -389,6 +389,8 @@ func (d *Dispatcher) processAlert(dispatchLink trace.Link, alert *types.Alert, r
 				// configuration reload or shutdown. In this case, the
 				// message should only be logged at the debug level.
 				lvl = level.Debug(l)
+			} else {
+				lvl = log.With(lvl, "alerts", fmt.Sprintf("%v", alerts))
 			}
 			lvl.Log("msg", "Notify for alerts failed", "num_alerts", len(alerts), "err", err)
 


### PR DESCRIPTION
Adding `alerts` instead of `num_alerts` to the `Notify for alerts failed` log message, so it's easier to understand which alerts we failed to send. We [log them](https://github.com/grafana/prometheus-alertmanager/blob/4563aec7a97580debb43cb7320932adbeda9bf2f/notify/notify.go#L894) in `Notify success` (but only in debug logging), but `Notify for alerts failed` currently logs only the number of alerts.

Before (see `num_alerts`)

```
ts=2025-04-17T08:43:39.183Z caller=dispatch.go:393 level=error component=dispatcher pipeline_time=2025-04-17T10:43:23.181754542+02:00 
msg="Notify for alerts failed" num_alerts=1 
err="webhook-parent/webhook[0]: notify retry canceled after 8 attempts: Post \"<redacted>\": dial tcp [::1]:15000: connect: connection refused"
```


After (see `alerts`)

```
ts=2025-04-17T08:41:15.046Z caller=dispatch.go:393 level=error component=dispatcher pipeline_time=2025-04-17T10:40:59.046255375+02:00 
msg="Notify for alerts failed" alerts=[alert[27c5096][active]] 
err="webhook-parent/webhook[0]: notify retry canceled after 8 attempts: Post \"<redacted>\": dial tcp [::1]:15000: connect: connection refused"
```