### PR TITLE
fix(matchers/compat): use legacy name validation scheme in classic mode

### DIFF
--- a/matchers/compat/parse.go
+++ b/matchers/compat/parse.go
@@ -190,7 +190,7 @@ func FallbackMatchersParser(l log.Logger) ParseMatchers {
 // isValidClassicLabelName returns true if the string is a valid classic label name.
 func isValidClassicLabelName(_ log.Logger) func(model.LabelName) bool {
 	return func(name model.LabelName) bool {
-		return name.IsValid()
+		return name.IsValidLegacy()
 	}
 }
 


### PR DESCRIPTION
When importing prometheus-alertmanager in a project with `prometheus/common` >= [v0.62.0](https://github.com/prometheus/common/releases/tag/v0.62.0) in [classic mode](https://prometheus.io/docs/alerting/latest/configuration/#classic-mode), calls to `compat.IsValidLabelName` use `UTF8Validation` scheme due to a new default for [NameValidationScheme](https://github.com/prometheus/common/blob/v0.62.0/model/metric.go#L37). This PR addresses this change by correctly using the legacy validation logic. 

As a workaround, we set `model.NameValidationScheme` to `model.LegacyValidation` e.g. in Mimir.

This is the identical upstream PR: https://github.com/prometheus/alertmanager/pull/4426