### PR TITLE
Use model.Duration for timeout option in webhook notifier

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -514,7 +514,7 @@ type WebhookConfig struct {
 
 	// Timeout is the maximum time allowed to invoke the webhook. Setting this to 0
 	// does not impose a timeout.
-	Timeout time.Duration `yaml:"timeout" json:"timeout"`
+	Timeout model.Duration `yaml:"timeout" json:"timeout"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/notify/webhook/webhook.go
+++ b/notify/webhook/webhook.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -125,7 +126,7 @@ func (n *Notifier) Notify(ctx context.Context, alerts ...*types.Alert) (bool, er
 	}
 
 	if n.conf.Timeout > 0 {
-		postCtx, cancel := context.WithTimeoutCause(ctx, n.conf.Timeout, fmt.Errorf("configured webhook timeout reached (%s)", n.conf.Timeout))
+		postCtx, cancel := context.WithTimeoutCause(ctx, time.Duration(n.conf.Timeout), fmt.Errorf("configured webhook timeout reached (%s)", n.conf.Timeout))
 		defer cancel()
 		ctx = postCtx
 	}


### PR DESCRIPTION
Upstream PR: https://github.com/prometheus/alertmanager/pull/4430

Should be safe to apply because yaml format does not change.

Copied description:

Changed webhook timeout field from `time.Duration` to `model.Duration` to make JSON marshalling consistent with YAML.

`time.Duration` marshals to JSON as an integer (nanoseconds), while to YAML (with `gopkg.in/yaml.v3`) it's marshalled as a duration string. 

`time.Duration` example: https://go.dev/play/p/Ml2Mb_VFNyu:

```
JSON: {"timeout":90000000000}
YAML: timeout: 1m30s
```

`model.Duration` also marshals to human-readable duration strings in both JSON and YAML, and is consistent with other duration fields in Alertmanager.

`model.Duration` example: https://go.dev/play/p/rqts9yDSEQL

```
JSON: {"timeout":"1m30s"}
YAML: timeout: 1m30s
```
