### PR TITLE
Add ExtraData field to Alert type

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -14,6 +14,7 @@
 package types
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"sync"
@@ -302,6 +303,9 @@ type Alert struct {
 	// The authoritative timestamp.
 	UpdatedAt time.Time
 	Timeout   bool
+
+	// Any additional data relevant to the alert
+	ExtraData json.RawMessage
 }
 
 func validateLs(ls model.LabelSet) error {


### PR DESCRIPTION
Adds a new field `ExtraData` of type `json.RawMessage` that allows any additional data with the alert to be passed around