### PR TITLE
Automatically wire SetIsReliableDelivery in AddState

### DIFF
--- a/cluster/channel.go
+++ b/cluster/channel.go
@@ -24,6 +24,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/prometheus/alertmanager/cluster/clusterpb"
+	"github.com/prometheus/alertmanager/cluster/clusterutil"
 )
 
 const defaultQueueSize = 200
@@ -188,11 +189,5 @@ func (c *Channel) Broadcast(b []byte) {
 // peers (via TCP), either because the channel is configured for reliable
 // delivery or because the message is oversized.
 func (c *Channel) ReliableDelivery(b []byte) bool {
-	return c.reliableDelivery || OversizedMessage(b)
-}
-
-// OversizedMessage indicates whether or not the byte payload should be sent
-// via TCP.
-func OversizedMessage(b []byte) bool {
-	return len(b) > MaxGossipPacketSize/2
+	return c.reliableDelivery || clusterutil.OversizedMessage(b)
 }

--- a/cluster/clusterutil/clusterutil.go
+++ b/cluster/clusterutil/clusterutil.go
@@ -1,0 +1,24 @@
+// Copyright 2018 Prometheus Team
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusterutil
+
+// MaxGossipPacketSize is the maximum size of a packet that gossip will send
+// via UDP. Packets larger than this are sent via TCP (reliable delivery).
+const MaxGossipPacketSize = 1400
+
+// OversizedMessage indicates whether or not the byte payload should be sent
+// via TCP.
+func OversizedMessage(b []byte) bool {
+	return len(b) > MaxGossipPacketSize/2
+}

--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -249,7 +249,6 @@ func run() int {
 	if peer != nil {
 		c := peer.AddState("nfl", notificationLog, prometheus.DefaultRegisterer)
 		notificationLog.SetBroadcast(c.Broadcast)
-		notificationLog.SetIsReliableDelivery(c.ReliableDelivery)
 	}
 
 	wg.Add(1)
@@ -279,7 +278,6 @@ func run() int {
 	if peer != nil {
 		c := peer.AddState("sil", silences, prometheus.DefaultRegisterer)
 		silences.SetBroadcast(c.Broadcast)
-		silences.SetIsReliableDelivery(c.ReliableDelivery)
 	}
 
 	// Start providers before router potentially sends updates.

--- a/flushlog/flushlog.go
+++ b/flushlog/flushlog.go
@@ -30,6 +30,7 @@ import (
 	"github.com/matttproud/golang_protobuf_extensions/pbutil"
 	"github.com/prometheus/client_golang/prometheus"
 
+	"github.com/prometheus/alertmanager/cluster/clusterutil"
 	pb "github.com/prometheus/alertmanager/flushlog/flushlogpb"
 )
 
@@ -240,7 +241,7 @@ func New(o Options) (*FlushLog, error) {
 		logger:             log.NewNopLogger(),
 		st:                 state{},
 		broadcast:          func([]byte) {},
-		isReliableDelivery: func([]byte) bool { return false },
+		isReliableDelivery: clusterutil.OversizedMessage,
 		metrics:            newMetrics(o.Metrics),
 	}
 

--- a/nflog/nflog.go
+++ b/nflog/nflog.go
@@ -33,6 +33,7 @@ import (
 	"github.com/matttproud/golang_protobuf_extensions/pbutil"
 	"github.com/prometheus/client_golang/prometheus"
 
+	"github.com/prometheus/alertmanager/cluster/clusterutil"
 	pb "github.com/prometheus/alertmanager/nflog/nflogpb"
 )
 
@@ -264,7 +265,7 @@ func New(o Options) (*Log, error) {
 		logger:             log.NewNopLogger(),
 		st:                 state{},
 		broadcast:          func([]byte) {},
-		isReliableDelivery: func([]byte) bool { return false },
+		isReliableDelivery: clusterutil.OversizedMessage,
 		metrics:            newMetrics(o.Metrics),
 	}
 

--- a/silence/silence.go
+++ b/silence/silence.go
@@ -36,6 +36,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 
+	"github.com/prometheus/alertmanager/cluster/clusterutil"
 	"github.com/prometheus/alertmanager/matchers/compat"
 	"github.com/prometheus/alertmanager/pkg/labels"
 	pb "github.com/prometheus/alertmanager/silence/silencepb"
@@ -356,7 +357,7 @@ func New(o Options) (*Silences, error) {
 		retention:          o.Retention,
 		limits:             o.Limits,
 		broadcast:          func([]byte) {},
-		isReliableDelivery: func([]byte) bool { return false },
+		isReliableDelivery: clusterutil.OversizedMessage,
 		st:                 state{},
 	}
 	s.metrics = newMetrics(o.Metrics, s)


### PR DESCRIPTION
I started merging https://github.com/grafana/prometheus-alertmanager/pull/144 to downstream consumers and had to manually call `SetIsReliableDelivery` after every AddState, which was easy to forget and would caused subtle bugs where merged state was unnecessarily re-broadcast. Changed `AddState` to now auto add it via the `ReliableDeliveryAware` interface, and default to `OversizedMessage` to keep the old behaviour. 

`OversizedMessage` moved to `cluster/clusterutil` to break the import cycle between `cluster` and the `state` packages.

Part of https://github.com/grafana/grafana/issues/116545

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cluster state propagation and re-broadcast decisions; mistakes could cause either extra gossip traffic or missed propagation. The change is small and covered by targeted tests but affects multiple state types.
> 
> **Overview**
> `Peer.AddState` now auto-injects the channel’s `ReliableDelivery` predicate into any `State` that implements the new `ReliableDeliveryAware` interface, removing the need for call sites to manually invoke `SetIsReliableDelivery`.
> 
> `OversizedMessage` and `MaxGossipPacketSize` are moved into a new `cluster/clusterutil` package to avoid import cycles; cluster channels and state packages (`silence`, `nflog`, `flushlog`) now default their reliable-delivery behavior to `clusterutil.OversizedMessage`. The Alertmanager main wiring is simplified by dropping explicit `SetIsReliableDelivery` calls, and new tests cover the auto-wiring and the default “don’t re-broadcast oversized messages” behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6df20f9e1e967ecc7e58482574f3ab7eaee53bdc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->