### PR TITLE
Export ResolveOptions for external ClusterPeer implementations

### DIFF
--- a/cluster/channel_test.go
+++ b/cluster/channel_test.go
@@ -74,6 +74,32 @@ func TestOversizedMessagesGossiped(t *testing.T) {
 	}
 }
 
+func TestResolveOptions(t *testing.T) {
+	t.Run("defaults", func(t *testing.T) {
+		resolved := ResolveOptions()
+		require.Equal(t, defaultQueueSize, resolved.QueueSize)
+		require.False(t, resolved.ReliableDelivery)
+	})
+
+	t.Run("with queue size", func(t *testing.T) {
+		resolved := ResolveOptions(WithQueueSize(500))
+		require.Equal(t, 500, resolved.QueueSize)
+		require.False(t, resolved.ReliableDelivery)
+	})
+
+	t.Run("with reliable delivery", func(t *testing.T) {
+		resolved := ResolveOptions(WithReliableDelivery(true))
+		require.Equal(t, defaultQueueSize, resolved.QueueSize)
+		require.True(t, resolved.ReliableDelivery)
+	})
+
+	t.Run("with both options", func(t *testing.T) {
+		resolved := ResolveOptions(WithReliableDelivery(true), WithQueueSize(1000))
+		require.Equal(t, 1000, resolved.QueueSize)
+		require.True(t, resolved.ReliableDelivery)
+	})
+}
+
 func TestWithQueueSizePanicsOnNonPositive(t *testing.T) {
 	require.Panics(t, func() { WithQueueSize(0) })
 	require.Panics(t, func() { WithQueueSize(-1) })


### PR DESCRIPTION
Add exported `ResolveOptions` function and `ChannelOptions` struct to the cluster package, allowing external `AddState` implementations to extract resolved configuration (queue size, reliable delivery) from `ChannelOption` values.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive API plus a minor refactor to reuse the same option resolution logic; runtime behavior should remain unchanged aside from any issues in the new resolver.
> 
> **Overview**
> Exports option resolution for cluster channels by adding `ChannelOptions` and `ResolveOptions`, allowing external implementations to derive effective `QueueSize` and `ReliableDelivery` from `ChannelOption` values.
> 
> Refactors `NewChannel` to use the shared resolver (no behavior change intended) and adds unit tests covering default and combined option resolution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c18d5b1986d802340cf4fc390f842f1a25d864b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->