### PR TITLE
Jira Integration: Allow configuring issue update via parameter (#4621)

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -187,9 +187,13 @@ var (
 		NotifierConfig: NotifierConfig{
 			VSendResolved: true,
 		},
-		Summary:     `{{ template "jira.default.summary" . }}`,
-		Description: `{{ template "jira.default.description" . }}`,
-		Priority:    `{{ template "jira.default.priority" . }}`,
+		Summary: JiraFieldConfig{
+			Template: `{{ template "jira.default.summary" . }}`,
+		},
+		Description: JiraFieldConfig{
+			Template: `{{ template "jira.default.description" . }}`,
+		},
+		Priority: `{{ template "jira.default.priority" . }}`,
 	}
 )
 
@@ -876,18 +880,24 @@ func (c *MSTeamsV2Config) UnmarshalYAML(unmarshal func(interface{}) error) error
 	return nil
 }
 
+type JiraFieldConfig struct {
+	Template string `yaml:"template,omitempty" json:"template,omitempty"`
+	// When false, omit this field when updating an existing issue.
+	EnableUpdate *bool `yaml:"enable_update,omitempty" json:"enable_update,omitempty"`
+}
+
 type JiraConfig struct {
 	NotifierConfig `yaml:",inline" json:",inline"`
 	HTTPConfig     *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 
 	APIURL *URL `yaml:"api_url,omitempty" json:"api_url,omitempty"`
 
-	Project     string   `yaml:"project,omitempty" json:"project,omitempty"`
-	Summary     string   `yaml:"summary,omitempty" json:"summary,omitempty"`
-	Description string   `yaml:"description,omitempty" json:"description,omitempty"`
-	Labels      []string `yaml:"labels,omitempty" json:"labels,omitempty"`
-	Priority    string   `yaml:"priority,omitempty" json:"priority,omitempty"`
-	IssueType   string   `yaml:"issue_type,omitempty" json:"issue_type,omitempty"`
+	Project     string          `yaml:"project,omitempty" json:"project,omitempty"`
+	Summary     JiraFieldConfig `yaml:"summary,omitempty" json:"summary,omitempty"`
+	Description JiraFieldConfig `yaml:"description,omitempty" json:"description,omitempty"`
+	Labels      []string        `yaml:"labels,omitempty" json:"labels,omitempty"`
+	Priority    string          `yaml:"priority,omitempty" json:"priority,omitempty"`
+	IssueType   string          `yaml:"issue_type,omitempty" json:"issue_type,omitempty"`
 
 	ReopenTransition  string         `yaml:"reopen_transition,omitempty" json:"reopen_transition,omitempty"`
 	ResolveTransition string         `yaml:"resolve_transition,omitempty" json:"resolve_transition,omitempty"`
@@ -895,6 +905,25 @@ type JiraConfig struct {
 	ReopenDuration    model.Duration `yaml:"reopen_duration,omitempty" json:"reopen_duration,omitempty"`
 
 	Fields map[string]any `yaml:"fields,omitempty" json:"custom_fields,omitempty"`
+}
+
+func (f *JiraFieldConfig) EnableUpdateValue() bool {
+	if f.EnableUpdate == nil {
+		return true
+	}
+
+	return *f.EnableUpdate
+}
+
+func (f *JiraFieldConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var tmpl string
+	if err := unmarshal(&tmpl); err == nil {
+		f.Template = tmpl
+		return nil
+	}
+
+	type plain JiraFieldConfig
+	return unmarshal((*plain)(f))
 }
 
 func (c *JiraConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {

--- a/config/notifiers_test.go
+++ b/config/notifiers_test.go
@@ -103,6 +103,48 @@ to: 'a@'
 	}
 }
 
+func TestJiraConfigSupportsLegacyAndStructuredFields(t *testing.T) {
+	t.Run("legacy string syntax", func(t *testing.T) {
+		in := `
+project: 'OPS'
+issue_type: 'Incident'
+summary: '{{ template "jira.default.summary" . }}'
+description: '{{ template "jira.default.description" . }}'
+`
+
+		var cfg JiraConfig
+		err := yaml.UnmarshalStrict([]byte(in), &cfg)
+		require.NoError(t, err)
+		require.Equal(t, `{{ template "jira.default.summary" . }}`, cfg.Summary.Template)
+		require.Equal(t, `{{ template "jira.default.description" . }}`, cfg.Description.Template)
+		require.True(t, cfg.Summary.EnableUpdateValue())
+		require.True(t, cfg.Description.EnableUpdateValue())
+	})
+
+	t.Run("structured syntax", func(t *testing.T) {
+		in := `
+project: 'OPS'
+issue_type: 'Incident'
+summary:
+  template: '{{ template "jira.default.summary" . }}'
+  enable_update: false
+description:
+  template: '{{ template "jira.default.description" . }}'
+  enable_update: true
+`
+
+		var cfg JiraConfig
+		err := yaml.UnmarshalStrict([]byte(in), &cfg)
+		require.NoError(t, err)
+		require.Equal(t, `{{ template "jira.default.summary" . }}`, cfg.Summary.Template)
+		require.Equal(t, `{{ template "jira.default.description" . }}`, cfg.Description.Template)
+		require.False(t, cfg.Summary.EnableUpdateValue())
+		require.True(t, cfg.Description.EnableUpdateValue())
+		require.NotNil(t, cfg.Summary.EnableUpdate)
+		require.NotNil(t, cfg.Description.EnableUpdate)
+	})
+}
+
 func TestPagerdutyTestRoutingKey(t *testing.T) {
 	t.Run("error if no routing key or key file", func(t *testing.T) {
 		in := `

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -997,11 +997,21 @@ The default `jira.default.description` template only works with V2.
 # The project key where issues are created.
 project: <string>
 
-# Issue summary template.
-[ summary: <tmpl_string> | default = '{{ template "jira.default.summary" . }}' ]
+# Issue summary configuration. A plain template string is also accepted for backward compatibility.
+[ summary:
+    [ template: <tmpl_string> | default = '{{ template "jira.default.summary" . }}' ]
 
-# Issue description template.
-[ description: <tmpl_string> | default = '{{ template "jira.default.description" . }}' ]
+    # If false, omit summary when updating an existing issue.
+    [ enable_update: <boolean> | default = true ]
+]
+
+# Issue description configuration. A plain template string is also accepted for backward compatibility.
+[ description:
+    [ template: <tmpl_string> | default = '{{ template "jira.default.description" . }}' ]
+
+    # If false, omit description when updating an existing issue.
+    [ enable_update: <boolean> | default = true ]
+]
 
 # Labels to be added to the issue.
 labels: 

--- a/notify/jira/jira.go
+++ b/notify/jira/jira.go
@@ -107,9 +107,18 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 		level.Debug(logger).Log("msg", "updating existing issue", "issue_key", existingIssue.Key)
 	}
 
-	requestBody, err := n.prepareIssueRequestBody(ctx, logger, key.Hash(), tmplTextFunc)
+	requestBody, err := n.prepareIssueRequestBody(logger, key.Hash(), tmplTextFunc)
 	if err != nil {
 		return false, err
+	}
+
+	if method == http.MethodPut && requestBody.Fields != nil {
+		if !n.conf.Description.EnableUpdateValue() {
+			requestBody.Fields.Description = nil
+		}
+		if !n.conf.Summary.EnableUpdateValue() {
+			requestBody.Fields.Summary = nil
+		}
 	}
 
 	_, shouldRetry, err = n.doAPIRequest(ctx, method, path, requestBody)
@@ -120,8 +129,8 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 	return n.transitionIssue(ctx, logger, existingIssue, alerts.HasFiring())
 }
 
-func (n *Notifier) prepareIssueRequestBody(ctx context.Context, logger log.Logger, groupID string, tmplTextFunc templateFunc) (issue, error) {
-	summary, err := tmplTextFunc(n.conf.Summary)
+func (n *Notifier) prepareIssueRequestBody(logger log.Logger, groupID string, tmplTextFunc templateFunc) (issue, error) {
+	summary, err := tmplTextFunc(n.conf.Summary.Template)
 	if err != nil {
 		return issue{}, fmt.Errorf("summary template: %w", err)
 	}
@@ -141,12 +150,12 @@ func (n *Notifier) prepareIssueRequestBody(ctx context.Context, logger log.Logge
 	requestBody := issue{Fields: &issueFields{
 		Project:   &issueProject{Key: n.conf.Project},
 		Issuetype: &idNameValue{Name: n.conf.IssueType},
-		Summary:   summary,
+		Summary:   &summary,
 		Labels:    make([]string, 0, len(n.conf.Labels)+1),
 		Fields:    fieldsWithStringKeys,
 	}}
 
-	issueDescriptionString, err := tmplTextFunc(n.conf.Description)
+	issueDescriptionString, err := tmplTextFunc(n.conf.Description.Template)
 	if err != nil {
 		return issue{}, fmt.Errorf("description template: %w", err)
 	}

--- a/notify/jira/jira_test.go
+++ b/notify/jira/jira_test.go
@@ -37,6 +37,18 @@ import (
 	"github.com/prometheus/alertmanager/types"
 )
 
+func stringPtr(v string) *string {
+	return &v
+}
+
+func boolPtr(v bool) *bool {
+	return &v
+}
+
+func jiraField(template string) config.JiraFieldConfig {
+	return config.JiraFieldConfig{Template: template}
+}
+
 func TestJiraRetry(t *testing.T) {
 	notifier, err := New(
 		&config.JiraConfig{
@@ -90,31 +102,31 @@ func TestJiraTemplating(t *testing.T) {
 		{
 			title: "full-blown message",
 			cfg: &config.JiraConfig{
-				Summary:     `{{ template "jira.default.summary" . }}`,
-				Description: `{{ template "jira.default.description" . }}`,
+				Summary:     jiraField(`{{ template "jira.default.summary" . }}`),
+				Description: jiraField(`{{ template "jira.default.description" . }}`),
 			},
 			retry: false,
 		},
 		{
 			title: "summary with templating errors",
 			cfg: &config.JiraConfig{
-				Summary: "{{ ",
+				Summary: jiraField("{{ "),
 			},
 			errMsg: "template: :1: unclosed action",
 		},
 		{
 			title: "description with templating errors",
 			cfg: &config.JiraConfig{
-				Summary:     `{{ template "jira.default.summary" . }}`,
-				Description: "{{ ",
+				Summary:     jiraField(`{{ template "jira.default.summary" . }}`),
+				Description: jiraField("{{ "),
 			},
 			errMsg: "template: :1: unclosed action",
 		},
 		{
 			title: "priority with templating errors",
 			cfg: &config.JiraConfig{
-				Summary:     `{{ template "jira.default.summary" . }}`,
-				Description: `{{ template "jira.default.description" . }}`,
+				Summary:     jiraField(`{{ template "jira.default.summary" . }}`),
+				Description: jiraField(`{{ template "jira.default.description" . }}`),
 				Priority:    "{{ ",
 			},
 			errMsg: "template: :1: unclosed action",
@@ -168,8 +180,8 @@ func TestJiraNotify(t *testing.T) {
 		{
 			title: "create new issue",
 			cfg: &config.JiraConfig{
-				Summary:           `{{ template "jira.default.summary" . }}`,
-				Description:       `{{ template "jira.default.description" . }}`,
+				Summary:           jiraField(`{{ template "jira.default.summary" . }}`),
+				Description:       jiraField(`{{ template "jira.default.description" . }}`),
 				IssueType:         "Incident",
 				Project:           "OPS",
 				Priority:          `{{ template "jira.default.priority" . }}`,
@@ -196,7 +208,7 @@ func TestJiraNotify(t *testing.T) {
 			issue: issue{
 				Key: "",
 				Fields: &issueFields{
-					Summary:     "[FIRING:1] test (vm1 critical)",
+					Summary:     stringPtr("[FIRING:1] test (vm1 critical)"),
 					Description: "\n\n# Alerts Firing:\n\nLabels:\n  - alertname = test\n  - instance = vm1\n  - severity = critical\n\nAnnotations:\n\nSource: \n\n\n\n\n",
 					Issuetype:   &idNameValue{Name: "Incident"},
 					Labels:      []string{"ALERT{6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b}", "alertmanager", "test"},
@@ -208,10 +220,75 @@ func TestJiraNotify(t *testing.T) {
 			errMsg:             "",
 		},
 		{
+			title: "update existing issue without summary and description updates",
+			cfg: &config.JiraConfig{
+				Summary: config.JiraFieldConfig{
+					Template:     `{{ template "jira.default.summary" . }}`,
+					EnableUpdate: boolPtr(false),
+				},
+				Description: config.JiraFieldConfig{
+					Template:     `{{ template "jira.default.description" . }}`,
+					EnableUpdate: boolPtr(false),
+				},
+				IssueType:         "Incident",
+				Project:           "OPS",
+				Priority:          `{{ template "jira.default.priority" . }}`,
+				Labels:            []string{"alertmanager", "{{ .GroupLabels.alertname }}"},
+				ReopenDuration:    model.Duration(1 * time.Hour),
+				ReopenTransition:  "REOPEN",
+				ResolveTransition: "CLOSE",
+				WontFixResolution: "WONTFIX",
+			},
+			alert: &types.Alert{
+				Alert: model.Alert{
+					Labels: model.LabelSet{
+						"alertname": "test",
+						"instance":  "vm1",
+						"severity":  "critical",
+					},
+					StartsAt: time.Now(),
+					EndsAt:   time.Now().Add(time.Hour),
+				},
+			},
+			searchResponse: issueSearchResult{
+				Issues: []issue{
+					{
+						Key: "OPS-4",
+						Fields: &issueFields{
+							Status: &issueStatus{
+								Name: "Open",
+								StatusCategory: struct {
+									Key string `json:"key"`
+								}{
+									Key: "open",
+								},
+							},
+						},
+					},
+				},
+			},
+			issue: issue{
+				Key: "",
+				Fields: &issueFields{
+					Issuetype: &idNameValue{Name: "Incident"},
+					Labels:    []string{"ALERT{6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b}", "alertmanager", "test"},
+					Project:   &issueProject{Key: "OPS"},
+					Priority:  &idNameValue{Name: "High"},
+				},
+			},
+			customFieldAssetFn: func(t *testing.T, issue map[string]any) {
+				_, hasSummary := issue["summary"]
+				_, hasDescription := issue["description"]
+				require.False(t, hasSummary)
+				require.False(t, hasDescription)
+			},
+			errMsg: "",
+		},
+		{
 			title: "create new issue with custom field and too long summary",
 			cfg: &config.JiraConfig{
-				Summary:     strings.Repeat("A", maxSummaryLenRunes+10),
-				Description: `{{ template "jira.default.description" . }}`,
+				Summary:     jiraField(strings.Repeat("A", maxSummaryLenRunes+10)),
+				Description: jiraField(`{{ template "jira.default.description" . }}`),
 				IssueType:   "Incident",
 				Project:     "OPS",
 				Priority:    `{{ template "jira.default.priority" . }}`,
@@ -248,7 +325,7 @@ func TestJiraNotify(t *testing.T) {
 			issue: issue{
 				Key: "",
 				Fields: &issueFields{
-					Summary:     strings.Repeat("A", maxSummaryLenRunes-1) + "…",
+					Summary:     stringPtr(strings.Repeat("A", maxSummaryLenRunes-1) + "…"),
 					Description: "\n\n# Alerts Firing:\n\nLabels:\n  - alertname = test\n  - instance = vm1\n\nAnnotations:\n\nSource: \n\n\n\n\n",
 					Issuetype:   &idNameValue{Name: "Incident"},
 					Labels:      []string{"ALERT{6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b}", "alertmanager", "test"},
@@ -270,8 +347,8 @@ func TestJiraNotify(t *testing.T) {
 		{
 			title: "reopen issue",
 			cfg: &config.JiraConfig{
-				Summary:           `{{ template "jira.default.summary" . }}`,
-				Description:       `{{ template "jira.default.description" . }}`,
+				Summary:           jiraField(`{{ template "jira.default.summary" . }}`),
+				Description:       jiraField(`{{ template "jira.default.description" . }}`),
 				IssueType:         "Incident",
 				Project:           "OPS",
 				Priority:          `{{ template "jira.default.priority" . }}`,
@@ -311,7 +388,7 @@ func TestJiraNotify(t *testing.T) {
 			issue: issue{
 				Key: "",
 				Fields: &issueFields{
-					Summary:     "[FIRING:1] test (vm1)",
+					Summary:     stringPtr("[FIRING:1] test (vm1)"),
 					Description: "\n\n# Alerts Firing:\n\nLabels:\n  - alertname = test\n  - instance = vm1\n\nAnnotations:\n\nSource: \n\n\n\n\n",
 					Issuetype:   &idNameValue{Name: "Incident"},
 					Labels:      []string{"ALERT{6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b}", "alertmanager", "test"},
@@ -325,8 +402,8 @@ func TestJiraNotify(t *testing.T) {
 		{
 			title: "error resolve transition not found",
 			cfg: &config.JiraConfig{
-				Summary:           `{{ template "jira.default.summary" . }}`,
-				Description:       `{{ template "jira.default.description" . }}`,
+				Summary:           jiraField(`{{ template "jira.default.summary" . }}`),
+				Description:       jiraField(`{{ template "jira.default.description" . }}`),
 				IssueType:         "Incident",
 				Project:           "OPS",
 				Priority:          `{{ template "jira.default.priority" . }}`,
@@ -366,7 +443,7 @@ func TestJiraNotify(t *testing.T) {
 			issue: issue{
 				Key: "",
 				Fields: &issueFields{
-					Summary:     "[RESOLVED] test (vm1)",
+					Summary:     stringPtr("[RESOLVED] test (vm1)"),
 					Description: "\n\n\n# Alerts Resolved:\n\nLabels:\n  - alertname = test\n  - instance = vm1\n\nAnnotations:\n\nSource: \n\n\n\n",
 					Issuetype:   &idNameValue{Name: "Incident"},
 					Labels:      []string{"ALERT{6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b}", "alertmanager", "test"},
@@ -379,8 +456,8 @@ func TestJiraNotify(t *testing.T) {
 		{
 			title: "error reopen transition not found",
 			cfg: &config.JiraConfig{
-				Summary:           `{{ template "jira.default.summary" . }}`,
-				Description:       `{{ template "jira.default.description" . }}`,
+				Summary:           jiraField(`{{ template "jira.default.summary" . }}`),
+				Description:       jiraField(`{{ template "jira.default.description" . }}`),
 				IssueType:         "Incident",
 				Project:           "OPS",
 				Priority:          `{{ template "jira.default.priority" . }}`,
@@ -420,7 +497,7 @@ func TestJiraNotify(t *testing.T) {
 			issue: issue{
 				Key: "",
 				Fields: &issueFields{
-					Summary:     "[FIRING:1] test (vm1)",
+					Summary:     stringPtr("[FIRING:1] test (vm1)"),
 					Description: "\n\n# Alerts Firing:\n\nLabels:\n  - alertname = test\n  - instance = vm1\n\nAnnotations:\n\nSource: \n\n\n\n\n",
 					Issuetype:   &idNameValue{Name: "Incident"},
 					Labels:      []string{"ALERT{6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b}", "alertmanager", "test"},
@@ -524,6 +601,7 @@ func TestJiraNotify(t *testing.T) {
 				case "/issue/OPS-1":
 				case "/issue/OPS-2":
 				case "/issue/OPS-3":
+				case "/issue/OPS-4":
 					fallthrough
 				case "/issue":
 					body, err := io.ReadAll(r.Body)
@@ -555,8 +633,6 @@ func TestJiraNotify(t *testing.T) {
 					} else {
 						t.Errorf("fields should a map of string")
 					}
-
-					w.WriteHeader(http.StatusCreated)
 
 					w.WriteHeader(http.StatusCreated)
 

--- a/notify/jira/types.go
+++ b/notify/jira/types.go
@@ -26,13 +26,13 @@ type issue struct {
 }
 
 type issueFields struct {
-	Description any           `json:"description"`
+	Description any           `json:"description,omitempty"`
 	Issuetype   *idNameValue  `json:"issuetype,omitempty"`
 	Labels      []string      `json:"labels,omitempty"`
 	Priority    *idNameValue  `json:"priority,omitempty"`
 	Project     *issueProject `json:"project,omitempty"`
 	Resolution  *idNameValue  `json:"resolution,omitempty"`
-	Summary     string        `json:"summary"`
+	Summary     *string       `json:"summary,omitempty"`
 	Status      *issueStatus  `json:"status,omitempty"`
 
 	Fields map[string]any `json:"-"`
@@ -70,9 +70,14 @@ type issueTransitions struct {
 
 // MarshalJSON merges the struct issueFields and issueFields.CustomField together.
 func (i issueFields) MarshalJSON() ([]byte, error) {
-	jsonFields := map[string]interface{}{
-		"description": i.Description,
-		"summary":     i.Summary,
+	jsonFields := map[string]interface{}{}
+
+	if i.Description != nil {
+		jsonFields["description"] = i.Description
+	}
+
+	if i.Summary != nil {
+		jsonFields["summary"] = *i.Summary
 	}
 
 	if i.Issuetype != nil {


### PR DESCRIPTION
Following up the discussion https://github.com/grafana/prometheus-alertmanager/pull/128#issuecomment-4031358832
I made the same changes already contributed to alertmanager upstream available to the grafana fork so It can be applied without doing a full rebase against upstream.

* Jira Integration: Allow configuring issue update via parameter

---------


(cherry picked from commit a90da796bd313df616136dcf8fa73ab4c8b5bc65)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes JIRA notification config schema and issue update payloads; while backward compatible, it can alter which fields are sent on issue updates and thus affect existing JIRA workflows.
> 
> **Overview**
> Adds structured `summary`/`description` configuration for JIRA (`template` + optional `enable_update`) while preserving legacy string syntax via custom YAML unmarshalling.
> 
> On issue updates (`PUT`), the notifier can now omit `summary` and/or `description` from the request body based on `enable_update`, and the JIRA request JSON types were adjusted (`Summary` pointer + `omitempty`) to support field omission. Docs and tests were updated to cover both config syntaxes and the new “skip updates” behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a830e016294491d58a34a9fd4f68de90ef1d3f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->