### PR TITLE
Fix memory leak when failing to deliver notifications for resolved alerts

### DIFF
--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -585,15 +585,11 @@ func (ag *aggrGroup) flush(ctx context.Context, nf notifyFunc) {
 		// and we don't want to send another one. However, we need to make sure
 		// that each resolved alert has not fired again during the flush as then
 		// we would delete an active alert thinking it was resolved.
-		if err := ag.alerts.DeleteIfNotModified(resolvedSlice); err != nil {
-			level.Error(l).Log("msg", "error on delete alerts", "err", err)
-		}
+		ag.alerts.DeleteIfNotModified(resolvedSlice)
 	} else {
-		// Delete resolved alerts after 3 * group_interval to avoid constant notification failures
-		// resulting in unbounded memory growth.
-		if err := ag.alerts.DeleteIfStale(resolvedSlice, ag.opts.GroupInterval*3); err != nil {
-			level.Error(l).Log("msg", "error on delete alerts", "err", err)
-		}
+		// Delete resolved alerts after 3 * group_interval to avoid persistent notification failures
+		// causing unbounded memory growth.
+		ag.alerts.DeleteIfStale(resolvedSlice, ag.opts.GroupInterval*3)
 	}
 }
 

--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -580,14 +580,12 @@ func (ag *aggrGroup) flush(ctx context.Context, nf notifyFunc) {
 
 	level.Debug(l).Log("msg", "flushing", "alerts", fmt.Sprintf("%v", alertsSlice))
 
-	if nf(ctx, alertsSlice...) {
-		// Delete all resolved alerts as we just sent a notification for them,
-		// and we don't want to send another one. However, we need to make sure
-		// that each resolved alert has not fired again during the flush as then
-		// we would delete an active alert thinking it was resolved.
-		if err := ag.alerts.DeleteIfNotModified(resolvedSlice); err != nil {
-			level.Error(l).Log("msg", "error on delete alerts", "err", err)
-		}
+	nf(ctx, alertsSlice...)
+	// Delete all resolved alerts regardless of notification outcome. We need
+	// to make sure that each resolved alert has not fired again during the
+	// flush as then we would delete an active alert thinking it was resolved.
+	if err := ag.alerts.DeleteIfNotModified(resolvedSlice); err != nil {
+		level.Error(l).Log("msg", "error on delete alerts", "err", err)
 	}
 }
 

--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -580,12 +580,20 @@ func (ag *aggrGroup) flush(ctx context.Context, nf notifyFunc) {
 
 	level.Debug(l).Log("msg", "flushing", "alerts", fmt.Sprintf("%v", alertsSlice))
 
-	nf(ctx, alertsSlice...)
-	// Delete all resolved alerts regardless of notification outcome. We need
-	// to make sure that each resolved alert has not fired again during the
-	// flush as then we would delete an active alert thinking it was resolved.
-	if err := ag.alerts.DeleteIfNotModified(resolvedSlice); err != nil {
-		level.Error(l).Log("msg", "error on delete alerts", "err", err)
+	if nf(ctx, alertsSlice...) {
+		// Delete all resolved alerts as we just sent a notification for them,
+		// and we don't want to send another one. However, we need to make sure
+		// that each resolved alert has not fired again during the flush as then
+		// we would delete an active alert thinking it was resolved.
+		if err := ag.alerts.DeleteIfNotModified(resolvedSlice); err != nil {
+			level.Error(l).Log("msg", "error on delete alerts", "err", err)
+		}
+	} else {
+		// Delete resolved alerts after 3 * group_interval to avoid constant notification failures
+		// resulting in unbounded memory growth.
+		if err := ag.alerts.DeleteIfStale(resolvedSlice, ag.opts.GroupInterval*3); err != nil {
+			level.Error(l).Log("msg", "error on delete alerts", "err", err)
+		}
 	}
 }
 

--- a/store/store.go
+++ b/store/store.go
@@ -128,6 +128,21 @@ func (a *Alerts) DeleteIfNotModified(alerts types.AlertSlice) error {
 	return nil
 }
 
+// DeleteIfStale deletes the slice of Alerts from the store if the time since the last update
+// is greater or equal than the TTL.
+func (a *Alerts) DeleteIfStale(alerts types.AlertSlice, ttl time.Duration) error {
+	a.Lock()
+	defer a.Unlock()
+	for _, alert := range alerts {
+		fp := alert.Fingerprint()
+		other, ok := a.c[fp]
+		if ok && alert.UpdatedAt.Equal(other.UpdatedAt) && time.Since(alert.UpdatedAt) >= ttl {
+			delete(a.c, fp)
+		}
+	}
+	return nil
+}
+
 // List returns a slice of Alerts currently held in memory.
 func (a *Alerts) List() []*types.Alert {
 	a.Lock()

--- a/store/store.go
+++ b/store/store.go
@@ -116,31 +116,38 @@ func (a *Alerts) Set(alert *types.Alert) error {
 
 // DeleteIfNotModified deletes the slice of Alerts from the store if not
 // modified.
-func (a *Alerts) DeleteIfNotModified(alerts types.AlertSlice) error {
+func (a *Alerts) DeleteIfNotModified(alerts types.AlertSlice) {
 	a.Lock()
 	defer a.Unlock()
+	a.deleteIfNotModified(alerts)
+}
+
+// DeleteIfStale deletes the slice of Alerts from the store if the time since
+// the last update is greater than or equal to the given TTL.
+func (a *Alerts) DeleteIfStale(alerts types.AlertSlice, ttl time.Duration) {
+	a.Lock()
+	defer a.Unlock()
+
+	// Filter out non-stale alerts.
+	stale := make(types.AlertSlice, 0, len(alerts))
+	for _, alert := range alerts {
+		if time.Since(alert.UpdatedAt) >= ttl {
+			stale = append(stale, alert)
+		}
+	}
+
+	a.deleteIfNotModified(stale)
+}
+
+// deleteIfNotModified deletes alerts from the store whose UpdatedAt has not changed.
+// Not thread-safe. The caller must hold the lock.
+func (a *Alerts) deleteIfNotModified(alerts types.AlertSlice) {
 	for _, alert := range alerts {
 		fp := alert.Fingerprint()
 		if other, ok := a.c[fp]; ok && alert.UpdatedAt.Equal(other.UpdatedAt) {
 			delete(a.c, fp)
 		}
 	}
-	return nil
-}
-
-// DeleteIfStale deletes the slice of Alerts from the store if the time since the last update
-// is greater or equal than the TTL.
-func (a *Alerts) DeleteIfStale(alerts types.AlertSlice, ttl time.Duration) error {
-	a.Lock()
-	defer a.Unlock()
-	for _, alert := range alerts {
-		fp := alert.Fingerprint()
-		other, ok := a.c[fp]
-		if ok && alert.UpdatedAt.Equal(other.UpdatedAt) && time.Since(alert.UpdatedAt) >= ttl {
-			delete(a.c, fp)
-		}
-	}
-	return nil
 }
 
 // List returns a slice of Alerts currently held in memory.

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -138,6 +138,72 @@ func TestDeleteIfNotModified(t *testing.T) {
 	})
 }
 
+func TestDeleteIfStale(t *testing.T) {
+	const ttl = time.Hour
+	now := time.Now()
+	staleTime := now.Add(-2 * ttl)
+	freshTime := now.Add(ttl)
+
+	newAlert := func(key, val string, updatedAt time.Time) *types.Alert {
+		return &types.Alert{
+			Alert:     model.Alert{Labels: model.LabelSet{model.LabelName(key): model.LabelValue(val)}},
+			UpdatedAt: updatedAt,
+		}
+	}
+
+	t.Run("stale alert is deleted", func(t *testing.T) {
+		a := NewAlerts()
+		alert := newAlert("foo", "bar", staleTime)
+		require.NoError(t, a.Set(alert))
+
+		a.DeleteIfStale(types.AlertSlice{alert}, ttl)
+
+		_, err := a.Get(alert.Fingerprint())
+		require.Equal(t, ErrNotFound, err)
+	})
+
+	t.Run("fresh alert is kept", func(t *testing.T) {
+		a := NewAlerts()
+		alert := newAlert("foo", "bar", freshTime)
+		require.NoError(t, a.Set(alert))
+
+		a.DeleteIfStale(types.AlertSlice{alert}, ttl)
+
+		got, err := a.Get(alert.Fingerprint())
+		require.NoError(t, err)
+		require.Equal(t, alert, got)
+	})
+
+	t.Run("modified alert is not deleted even if stale", func(t *testing.T) {
+		a := NewAlerts()
+		old := newAlert("foo", "bar", staleTime)
+		newer := newAlert("foo", "bar", freshTime)
+		require.NoError(t, a.Set(newer))
+
+		a.DeleteIfStale(types.AlertSlice{old}, ttl)
+
+		got, err := a.Get(newer.Fingerprint())
+		require.NoError(t, err)
+		require.Equal(t, newer, got)
+	})
+
+	t.Run("only stale alerts are deleted, fresh ones are kept", func(t *testing.T) {
+		a := NewAlerts()
+		stale := newAlert("stale", "yes", staleTime)
+		fresh := newAlert("fresh", "yes", freshTime)
+		require.NoError(t, a.Set(stale))
+		require.NoError(t, a.Set(fresh))
+
+		a.DeleteIfStale(types.AlertSlice{stale, fresh}, ttl)
+
+		_, err := a.Get(stale.Fingerprint())
+		require.Equal(t, ErrNotFound, err)
+		got, err := a.Get(fresh.Fingerprint())
+		require.NoError(t, err)
+		require.Equal(t, fresh, got)
+	})
+}
+
 func TestGC(t *testing.T) {
 	now := time.Now()
 	newAlert := func(key string, start, end time.Duration) *types.Alert {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -126,7 +126,7 @@ func TestDeleteIfNotModified(t *testing.T) {
 		require.NoError(t, a.Set(a2))
 
 		// Deleting a1 should not delete a2.
-		require.NoError(t, a.DeleteIfNotModified(types.AlertSlice{a1}))
+		a.DeleteIfNotModified(types.AlertSlice{a1})
 		// a1 should be deleted.
 		got, err := a.Get(a1.Fingerprint())
 		require.Equal(t, ErrNotFound, err)


### PR DESCRIPTION
### Problem

Resolved alerts accumulate in the `aggrGroup` when notifications fail persistently.

`DeleteIfNotModified` is only [called](https://github.com/grafana/prometheus-alertmanager/blob/34faacdbc6358287bb2c78e343447d77547979c4/dispatch/dispatch.go#L588) on notification success, so when a receiver is consistently broken (413, 429, connection failures, etc), resolved alerts are never removed from memory. This causes unbounded memory growth.

### Fix

On success, behavior is unchanged: `DeleteIfNotModified` removes resolved alerts immediately after delivery.

On failure, a new `DeleteIfStale` method is used instead. Resolved alerts are kept for up to `3 * group_interval`, giving the receiver time to recover and still receive the resolution notification. Once that window expires, they're evicted regardless. The `UpdatedAt` equality check is preserved in both paths. Alerts that re-fired during the flush are not incorrectly removed.

#### Testing

I tested this by spinning up two Alertmanagers: one with the fix, another one without it. I created a script to constantly generate alerts that go from _active_ to _resolved_. These accumulated in the Alertmanager without the fix, but were properly evicted from the one with the fix.

<details>
<summary>Same alert rate in both Alertmanagers</summary>
<img width="1747" height="826" alt="alert_rate" src="https://github.com/user-attachments/assets/bee2af82-556e-4a98-9601-71dd959b8da9" />
</details>
<details>
<summary>Memory usage is constant in the non-leaky variant</summary>
<img width="1747" height="826" alt="memory_leak" src="https://github.com/user-attachments/assets/7302e3b7-5207-44ce-acd1-0b20ac59e5bb" />
</details>

### Note

We're currently returning an error from DeleteIfNotModified, but the method [always returns `nil`](https://github.com/grafana/prometheus-alertmanager/blob/34faacdbc6358287bb2c78e343447d77547979c4/store/store.go#L128). I removed this return value from the method's signature.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes alert eviction behavior in `aggrGroup.flush` so resolved alerts can be dropped after a TTL when notifications keep failing; misconfiguration of `group_interval` or edge timing could cause missed resolved notifications, but the UpdatedAt guard reduces risk of deleting re-fired alerts.
> 
> **Overview**
> Prevents unbounded in-memory growth of resolved alerts when notification delivery fails persistently.
> 
> `aggrGroup.flush` now deletes resolved alerts immediately only on successful notify; on failure it evicts resolved alerts once they are stale (>= `3 * group_interval`). The store API is adjusted accordingly by making `DeleteIfNotModified` non-erroring, adding `DeleteIfStale`, and introducing shared internal deletion logic with new unit tests covering stale vs fresh/modified behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33d11663ae91237d439973950e4004d69a603b7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->