### PR TITLE
Demote notification error logs to warning level

### DIFF
--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -391,7 +391,7 @@ func (d *Dispatcher) processAlert(dispatchLink trace.Link, alert *types.Alert, r
 
 		_, _, err := d.stage.Exec(ctx, l, alerts...)
 		if err != nil {
-			lvl := level.Error(l)
+			lvl := level.Warn(l)
 			if errors.Is(ctx.Err(), context.Canceled) {
 				// It is expected for the context to be canceled on
 				// configuration reload or shutdown. In this case, the


### PR DESCRIPTION
Errors in notification delivery are expected. These happen mostly due to misconfigurations or problems in third-party systems.

Not all errors should be logged at "error" level. These lines don't require our attention; they are just noise. They might make sense in the context of a single-tenant Alertmanager (upstream), but not in a multi-tenant system.

I'm demoting these lines to "warn" level. Debug-level logs would also be appropriate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes the log level for notification delivery failures; execution, retry behavior, and tracing/error reporting are unchanged.
> 
> **Overview**
> Demotes dispatcher notification delivery failures from **error** to **warn** logging in `dispatch/dispatch.go`, while still logging context-cancellation cases at **debug**.
> 
> Tracing error recording and span status setting remain the same; only the emitted log severity changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff3091c8ba731048f3559d75f9ba63cc518dbce3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->