### PR TITLE
fix(flushlog): retain tombstones to prevent gossip ping-pong

### DIFF
--- a/flushlog/flushlog.go
+++ b/flushlog/flushlog.go
@@ -437,6 +437,12 @@ func (l *FlushLog) Log(groupFingerprint uint64, flushTime, expiryThreshold time.
 // stays pinned to its original flush time would produce a tombstone whose
 // Timestamp + retention is already in the past, and GC would sweep it on
 // the next tick — letting in-flight refresh broadcasts resurrect the entry.
+//
+// The tombstone is built as a fresh MeshFlushLog (including a fresh inner
+// FlushLog) rather than mutating the in-map pointer. Query returns the
+// inner *pb.FlushLog by reference and releases the read lock before the
+// caller dereferences fields like Timestamp; mutating the shared pointer
+// would race those readers on time.Time's multi-word value.
 func (l *FlushLog) Delete(groupFingerprint uint64) error {
 	l.mtx.Lock()
 	defer l.mtx.Unlock()
@@ -451,12 +457,20 @@ func (l *FlushLog) Delete(groupFingerprint uint64) error {
 	}
 
 	now := l.now()
-	fl.ExpiresAt = time.Time{} // mark as tombstone in place; entry stays in state
-	if fl.FlushLog.Timestamp.Before(now) {
-		fl.FlushLog.Timestamp = now
+	ts := fl.FlushLog.Timestamp
+	if ts.Before(now) {
+		ts = now
 	}
+	tomb := &pb.MeshFlushLog{
+		FlushLog: &pb.FlushLog{
+			GroupFingerprint: fl.FlushLog.GroupFingerprint,
+			Timestamp:        ts,
+		},
+		ExpiresAt: time.Time{},
+	}
+	l.st[groupFingerprint] = tomb
 
-	b, err := marshalMeshFlushLog(fl)
+	b, err := marshalMeshFlushLog(tomb)
 	if err != nil {
 		return err
 	}

--- a/flushlog/flushlog.go
+++ b/flushlog/flushlog.go
@@ -146,15 +146,40 @@ func (s state) clone() state {
 
 // merge returns true or false whether the MeshFlushLog was merged or
 // not. This information is used to decide to gossip the message further.
+//
+// Tombstones (entries with zero ExpiresAt) are retained in state rather than
+// being removed: a deletion that drops the local entry would let an
+// in-flight refresh broadcast for the same group_fingerprint re-add the
+// entry, causing a gossip ping-pong (the deleted and refreshed messages
+// would oscillate between peers). Keeping the tombstone with the original
+// Timestamp lets the entry-path's Timestamp.Before check reject stale
+// refreshes naturally. Tombstones are GC'd in FlushLog.GC once
+// Timestamp + retention has elapsed.
 func (s state) merge(e *pb.MeshFlushLog, now time.Time) bool {
-	if e.ExpiresAt.IsZero() { // handle delete broadcasts
-		if prev, ok := s[e.FlushLog.GroupFingerprint]; !ok {
+	if e.ExpiresAt.IsZero() { // tombstone
+		prev, ok := s[e.FlushLog.GroupFingerprint]
+		if !ok {
+			// No prior knowledge of this group; record the tombstone so any
+			// future stale refresh broadcast can be rejected by Timestamp.
+			s[e.FlushLog.GroupFingerprint] = e
+			return true
+		}
+		if prev.ExpiresAt.IsZero() {
+			// Prev is already a tombstone; only a strictly newer Timestamp
+			// is propagated further to avoid endless re-gossip of identical
+			// tombstones.
+			if prev.FlushLog.Timestamp.Before(e.FlushLog.Timestamp) {
+				s[e.FlushLog.GroupFingerprint] = e
+				return true
+			}
 			return false
-		} else if prev.FlushLog.Timestamp.Before(e.FlushLog.Timestamp) || prev.FlushLog.Timestamp.Equal(e.FlushLog.Timestamp) {
-			// only delete if the incoming entry is newer
-			// since on expire the flushlog gets recreated, this can lead to a race condition
-			// causing the previous entry delete message to arrive after the new entry
-			delete(s, e.FlushLog.GroupFingerprint)
+		}
+		// Prev is a live entry; tombstone wins if its Timestamp is at least
+		// as new as the entry's (since on near-expiry the flushlog gets
+		// re-broadcast with the same Timestamp, the delete needs to defeat
+		// in-flight refreshes that carry the same Timestamp).
+		if prev.FlushLog.Timestamp.Before(e.FlushLog.Timestamp) || prev.FlushLog.Timestamp.Equal(e.FlushLog.Timestamp) {
+			s[e.FlushLog.GroupFingerprint] = e
 			return true
 		}
 		return false
@@ -368,7 +393,7 @@ func (l *FlushLog) Log(groupFingerprint uint64, flushTime, expiryThreshold time.
 		ExpiresAt: expiresAt,
 	}
 
-	if prevle, ok := l.st[groupFingerprint]; ok {
+	if prevle, ok := l.st[groupFingerprint]; ok && !prevle.ExpiresAt.IsZero() {
 		// minimize gossip by logging once per expiry period
 		// - expiry is based on the time given by the flush log clock and is set on the mesh struct.
 		// - we don't have any of that here, so based on flush time (which is before the flushlog clock time)
@@ -384,6 +409,11 @@ func (l *FlushLog) Log(groupFingerprint uint64, flushTime, expiryThreshold time.
 			e.FlushLog = prevle.FlushLog // keep previous timestamp
 		}
 	}
+	// If prevle is a tombstone we intentionally fall through here: the new
+	// flush must use the fresh flushTime so its Timestamp is strictly newer
+	// than the tombstone's, allowing peers to accept it via state.merge's
+	// entry-path. Carrying the tombstone's Timestamp would deadlock the
+	// group on every peer until GC sweeps the tombstone.
 
 	b, err := marshalMeshFlushLog(e)
 	if err != nil {
@@ -395,7 +425,11 @@ func (l *FlushLog) Log(groupFingerprint uint64, flushTime, expiryThreshold time.
 	return nil
 }
 
-// Delete removes the entry for the given group fingerprint from the log.
+// Delete marks the entry for the given group fingerprint as a tombstone and
+// broadcasts it. The tombstone is retained in state (rather than being
+// removed) so that stale refresh broadcasts arriving after the delete
+// cannot resurrect the entry — see state.merge for the full rationale.
+// Tombstones are eventually swept by FlushLog.GC.
 func (l *FlushLog) Delete(groupFingerprint uint64) error {
 	l.mtx.Lock()
 	defer l.mtx.Unlock()
@@ -404,9 +438,12 @@ func (l *FlushLog) Delete(groupFingerprint uint64) error {
 	if !ok {
 		return ErrNotFound
 	}
+	if fl.ExpiresAt.IsZero() {
+		// Already tombstoned; nothing to do.
+		return nil
+	}
 
-	delete(l.st, groupFingerprint)
-	fl.ExpiresAt = time.Time{} // broadcast expired log
+	fl.ExpiresAt = time.Time{} // mark as tombstone in place; entry stays in state
 
 	b, err := marshalMeshFlushLog(fl)
 	if err != nil {
@@ -417,7 +454,10 @@ func (l *FlushLog) Delete(groupFingerprint uint64) error {
 	return nil
 }
 
-// GC implements the Log interface.
+// GC implements the Log interface. Live entries are swept when their
+// ExpiresAt has passed. Tombstones (ExpiresAt zero) are swept once
+// FlushLog.Timestamp + retention has passed — long enough for in-flight
+// gossip refresh messages to drain so they can't resurrect a deleted entry.
 func (l *FlushLog) GC() (int, error) {
 	start := time.Now()
 	defer func() { l.metrics.gcDuration.Observe(time.Since(start).Seconds()) }()
@@ -429,6 +469,13 @@ func (l *FlushLog) GC() (int, error) {
 	defer l.mtx.Unlock()
 
 	for k, le := range l.st {
+		if le.ExpiresAt.IsZero() {
+			if le.FlushLog.Timestamp.Add(l.retention).Before(now) {
+				delete(l.st, k)
+				n++
+			}
+			continue
+		}
 		if !le.ExpiresAt.After(now) {
 			delete(l.st, k)
 			n++
@@ -452,7 +499,7 @@ func (l *FlushLog) Query(groupFingerprint uint64) ([]*pb.FlushLog, error) {
 		l.mtx.RLock()
 		defer l.mtx.RUnlock()
 
-		if le, ok := l.st[groupFingerprint]; ok {
+		if le, ok := l.st[groupFingerprint]; ok && !le.ExpiresAt.IsZero() {
 			return []*pb.FlushLog{le.FlushLog}, nil
 		}
 		return nil, ErrNotFound

--- a/flushlog/flushlog.go
+++ b/flushlog/flushlog.go
@@ -151,10 +151,10 @@ func (s state) clone() state {
 // being removed: a deletion that drops the local entry would let an
 // in-flight refresh broadcast for the same group_fingerprint re-add the
 // entry, causing a gossip ping-pong (the deleted and refreshed messages
-// would oscillate between peers). Keeping the tombstone with the original
-// Timestamp lets the entry-path's Timestamp.Before check reject stale
-// refreshes naturally. Tombstones are GC'd in FlushLog.GC once
-// Timestamp + retention has elapsed.
+// would oscillate between peers). Keeping the tombstone with a Timestamp
+// at least as recent as the deleted entry's lets the entry-path's
+// Timestamp.Before check reject stale refreshes naturally. Tombstones are
+// GC'd in FlushLog.GC once Timestamp + retention has elapsed.
 func (s state) merge(e *pb.MeshFlushLog, now time.Time) bool {
 	if e.ExpiresAt.IsZero() { // tombstone
 		prev, ok := s[e.FlushLog.GroupFingerprint]
@@ -429,7 +429,14 @@ func (l *FlushLog) Log(groupFingerprint uint64, flushTime, expiryThreshold time.
 // broadcasts it. The tombstone is retained in state (rather than being
 // removed) so that stale refresh broadcasts arriving after the delete
 // cannot resurrect the entry — see state.merge for the full rationale.
-// Tombstones are eventually swept by FlushLog.GC.
+//
+// The tombstone's FlushLog.Timestamp is bumped to now (or kept if already
+// later — possible under clock skew across peers) so FlushLog.GC sweeps it
+// at deletion_time + retention regardless of how long the underlying entry
+// was alive. Without this, a long-firing alert whose FlushLog.Timestamp
+// stays pinned to its original flush time would produce a tombstone whose
+// Timestamp + retention is already in the past, and GC would sweep it on
+// the next tick — letting in-flight refresh broadcasts resurrect the entry.
 func (l *FlushLog) Delete(groupFingerprint uint64) error {
 	l.mtx.Lock()
 	defer l.mtx.Unlock()
@@ -443,7 +450,11 @@ func (l *FlushLog) Delete(groupFingerprint uint64) error {
 		return nil
 	}
 
+	now := l.now()
 	fl.ExpiresAt = time.Time{} // mark as tombstone in place; entry stays in state
+	if fl.FlushLog.Timestamp.Before(now) {
+		fl.FlushLog.Timestamp = now
+	}
 
 	b, err := marshalMeshFlushLog(fl)
 	if err != nil {

--- a/flushlog/flushlog_test.go
+++ b/flushlog/flushlog_test.go
@@ -63,17 +63,20 @@ func TestLogGC(t *testing.T) {
 func TestLogDelete(t *testing.T) {
 	mockClock := clock.NewMock()
 	now := mockClock.Now()
-	// We only care about key names and expiration timestamps.
-	newFlushLog := func(ts time.Time) *pb.MeshFlushLog {
+	newFlushLog := func(fp uint64, ts, exp time.Time) *pb.MeshFlushLog {
 		return &pb.MeshFlushLog{
-			ExpiresAt: ts,
+			FlushLog: &pb.FlushLog{
+				GroupFingerprint: fp,
+				Timestamp:        ts,
+			},
+			ExpiresAt: exp,
 		}
 	}
 
 	l := &FlushLog{
 		st: state{
-			1: newFlushLog(now),
-			2: newFlushLog(now.Add(time.Second)),
+			1: newFlushLog(1, now, now.Add(time.Hour)),
+			2: newFlushLog(2, now, now.Add(time.Second)),
 		},
 		clock:     mockClock,
 		metrics:   newMetrics(nil),
@@ -82,10 +85,13 @@ func TestLogDelete(t *testing.T) {
 	err := l.Delete(1)
 	require.NoError(t, err, "unexpected delete error")
 
+	// Tombstone retained in state with the original FlushLog.Timestamp and
+	// ExpiresAt zeroed; entry 2 untouched.
 	expected := state{
-		2: newFlushLog(now.Add(time.Second)),
+		1: newFlushLog(1, now, time.Time{}),
+		2: newFlushLog(2, now, now.Add(time.Second)),
 	}
-	require.Equal(t, expected, l.st, "unexpected state after garbage collection")
+	require.Equal(t, expected, l.st, "unexpected state after delete")
 }
 
 func TestLogSnapshot(t *testing.T) {
@@ -268,27 +274,30 @@ func TestStateMerge(t *testing.T) {
 				3: newFlushLog(3, now.Add(time.Minute), exp),                         // newer timestamp, should overwrite
 				4: newFlushLog(4, now, exp),                                          // new key, should be added
 				5: newFlushLog(5, now.Add(-time.Minute), now.Add(-time.Millisecond)), // new key, expired, should not be added
-				6: newFlushLog(6, now.Add(time.Minute), time.Time{}),                 // zero expiration, should be deleted
+				6: newFlushLog(6, now.Add(time.Minute), time.Time{}),                 // tombstone, overwrites entry as tombstone
 			},
 			final: state{
 				1: newFlushLog(1, now, exp),
 				2: newFlushLog(2, now, exp),
 				3: newFlushLog(3, now.Add(time.Minute), exp),
 				4: newFlushLog(4, now, exp),
+				6: newFlushLog(6, now.Add(time.Minute), time.Time{}), // tombstone retained
 			},
 		},
 		{
-			name: "deletes when expiration is zero and timestamp is after previous entry",
+			name: "marks tombstone when expiration is zero and timestamp is after previous entry",
 			a: state{
 				1: newFlushLog(1, now, exp),
 			},
 			b: state{
-				1: newFlushLog(1, now.Add(time.Minute), time.Time{}), // zero expiration, should be deleted
+				1: newFlushLog(1, now.Add(time.Minute), time.Time{}),
 			},
-			final: state{},
+			final: state{
+				1: newFlushLog(1, now.Add(time.Minute), time.Time{}),
+			},
 		},
 		{
-			name: "doesn't delete when timestamp is before previous entry",
+			name: "doesn't tombstone when timestamp is before previous entry",
 			a: state{
 				1: newFlushLog(1, now, exp),
 			},
@@ -297,6 +306,64 @@ func TestStateMerge(t *testing.T) {
 			},
 			final: state{
 				1: newFlushLog(1, now, exp),
+			},
+		},
+		{
+			name: "doesn't resurrect entry after tombstone with same timestamp",
+			a: state{
+				1: newFlushLog(1, now, time.Time{}), // tombstone already in state
+			},
+			b: state{
+				1: newFlushLog(1, now, exp), // stale refresh broadcast — same Timestamp T
+			},
+			final: state{
+				1: newFlushLog(1, now, time.Time{}), // tombstone preserved
+			},
+		},
+		{
+			name: "newer flush overrides tombstone",
+			a: state{
+				1: newFlushLog(1, now, time.Time{}),
+			},
+			b: state{
+				1: newFlushLog(1, now.Add(time.Minute), exp), // newer flush — Timestamp T2 > T1
+			},
+			final: state{
+				1: newFlushLog(1, now.Add(time.Minute), exp),
+			},
+		},
+		{
+			name: "older entry doesn't override tombstone with same timestamp",
+			a: state{
+				1: newFlushLog(1, now, time.Time{}),
+			},
+			b: state{
+				1: newFlushLog(1, now.Add(-time.Minute), exp),
+			},
+			final: state{
+				1: newFlushLog(1, now, time.Time{}),
+			},
+		},
+		{
+			name: "stores tombstone with no prev to reject future stale refreshes",
+			a:    state{},
+			b: state{
+				1: newFlushLog(1, now, time.Time{}),
+			},
+			final: state{
+				1: newFlushLog(1, now, time.Time{}),
+			},
+		},
+		{
+			name: "newer tombstone overrides older tombstone",
+			a: state{
+				1: newFlushLog(1, now, time.Time{}),
+			},
+			b: state{
+				1: newFlushLog(1, now.Add(time.Minute), time.Time{}),
+			},
+			final: state{
+				1: newFlushLog(1, now.Add(time.Minute), time.Time{}),
 			},
 		},
 	}
@@ -312,6 +379,70 @@ func TestStateMerge(t *testing.T) {
 			require.Equal(t, c.final, res, "Merge result should match expectation")
 			require.Equal(t, c.b, cb, "Merged state should remain unmodified")
 			require.Equal(t, c.a, ca, "Merge should not change original state")
+		})
+	}
+}
+
+// TestStateMergeGossipPropagation asserts that merge() returns true/false in
+// the right cases so that ping-pong gossip on tombstones doesn't occur.
+func TestStateMergeGossipPropagation(t *testing.T) {
+	mockClock := clock.NewMock()
+	now := mockClock.Now()
+
+	newFlushLog := func(fp uint64, ts, exp time.Time) *pb.MeshFlushLog {
+		return &pb.MeshFlushLog{
+			FlushLog: &pb.FlushLog{
+				GroupFingerprint: fp,
+				Timestamp:        ts,
+			},
+			ExpiresAt: exp,
+		}
+	}
+	exp := now.Add(time.Minute)
+
+	cases := []struct {
+		name   string
+		prev   state
+		in     *pb.MeshFlushLog
+		merged bool
+	}{
+		{
+			name:   "tombstone over entry with same timestamp: merged once",
+			prev:   state{1: newFlushLog(1, now, exp)},
+			in:     newFlushLog(1, now, time.Time{}),
+			merged: true,
+		},
+		{
+			name:   "tombstone equal to stored tombstone: not re-gossiped",
+			prev:   state{1: newFlushLog(1, now, time.Time{})},
+			in:     newFlushLog(1, now, time.Time{}),
+			merged: false,
+		},
+		{
+			name:   "older tombstone vs stored tombstone: not re-gossiped",
+			prev:   state{1: newFlushLog(1, now, time.Time{})},
+			in:     newFlushLog(1, now.Add(-time.Minute), time.Time{}),
+			merged: false,
+		},
+		{
+			name:   "stale refresh after tombstone: not re-gossiped",
+			prev:   state{1: newFlushLog(1, now, time.Time{})},
+			in:     newFlushLog(1, now, exp),
+			merged: false,
+		},
+		{
+			name:   "newer flush after tombstone: merged",
+			prev:   state{1: newFlushLog(1, now, time.Time{})},
+			in:     newFlushLog(1, now.Add(time.Minute), exp),
+			merged: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			s := c.prev.clone()
+			got := s.merge(c.in, now)
+			require.Equal(t, c.merged, got, "unexpected merge return value")
 		})
 	}
 }
@@ -388,6 +519,105 @@ func TestQuery(t *testing.T) {
 	entry := entries[0]
 	require.Equal(t, uint64(1), entry.GroupFingerprint, "unexpected group fingerprint")
 	require.Equal(t, now, entry.Timestamp, "unexpected group fingerprint")
+}
+
+// TestQuery_Tombstone asserts that Query treats a tombstone-marked entry as
+// not-found so callers can't observe a phantom flushlog entry.
+func TestQuery_Tombstone(t *testing.T) {
+	mockClock := clock.NewMock()
+	now := mockClock.Now()
+
+	l := &FlushLog{
+		clock:   mockClock,
+		metrics: newMetrics(nil),
+		st: state{
+			1: &pb.MeshFlushLog{
+				FlushLog: &pb.FlushLog{
+					GroupFingerprint: 1,
+					Timestamp:        now,
+				},
+				ExpiresAt: time.Time{},
+			},
+		},
+	}
+	_, err := l.Query(1)
+	require.ErrorIs(t, err, ErrNotFound, "Query must hide tombstones from callers")
+}
+
+// TestLog_AfterTombstone asserts that calling Log() when the previous entry
+// is a tombstone produces a fresh entry with the new flushTime and a valid
+// ExpiresAt — i.e. the tombstone doesn't sink the new flush via the
+// closeToExpiry / Timestamp-carry-over branch.
+func TestLog_AfterTombstone(t *testing.T) {
+	mockClock := clock.NewMock()
+	t1 := mockClock.Now()
+	mockClock.Add(time.Hour)
+	t2 := mockClock.Now()
+
+	var broadcasts [][]byte
+	l := &FlushLog{
+		clock:     mockClock,
+		retention: 24 * time.Hour,
+		logger:    nil,
+		metrics:   newMetrics(nil),
+		broadcast: func(b []byte) { broadcasts = append(broadcasts, b) },
+		st: state{
+			1: &pb.MeshFlushLog{
+				FlushLog: &pb.FlushLog{
+					GroupFingerprint: 1,
+					Timestamp:        t1,
+				},
+				ExpiresAt: time.Time{}, // tombstone
+			},
+		},
+	}
+
+	err := l.Log(1, t2, t2.Add(time.Hour), 0)
+	require.NoError(t, err)
+
+	got, ok := l.st[1]
+	require.True(t, ok, "expected fresh entry in state after Log post-tombstone")
+	require.False(t, got.ExpiresAt.IsZero(), "expected real entry, got tombstone")
+	require.Equal(t, t2, got.FlushLog.Timestamp, "expected fresh Timestamp (t2), not tombstone's Timestamp (t1)")
+	require.Len(t, broadcasts, 1, "expected exactly one broadcast")
+}
+
+// TestLogGC_Tombstones asserts GC retains tombstones until
+// FlushLog.Timestamp + retention has passed, then sweeps them.
+func TestLogGC_Tombstones(t *testing.T) {
+	mockClock := clock.NewMock()
+	now := mockClock.Now()
+	retention := time.Hour
+
+	entry := func(fp uint64, ts, exp time.Time) *pb.MeshFlushLog {
+		return &pb.MeshFlushLog{
+			FlushLog: &pb.FlushLog{
+				GroupFingerprint: fp,
+				Timestamp:        ts,
+			},
+			ExpiresAt: exp,
+		}
+	}
+
+	l := &FlushLog{
+		clock:     mockClock,
+		retention: retention,
+		metrics:   newMetrics(nil),
+		st: state{
+			1: entry(1, now, now.Add(time.Second)),                      // entry, ExpiresAt still in future — keep
+			2: entry(2, now.Add(-2*time.Hour), now.Add(-time.Second)),   // entry, expired — sweep
+			3: entry(3, now, time.Time{}),                               // tombstone, Timestamp+retention in future — keep
+			4: entry(4, now.Add(-2*retention), time.Time{}),             // tombstone, Timestamp+retention in past — sweep
+		},
+	}
+
+	n, err := l.GC()
+	require.NoError(t, err)
+	require.Equal(t, 2, n, "expected two entries swept (one expired entry, one expired tombstone)")
+	require.Contains(t, l.st, uint64(1), "fresh entry must survive GC")
+	require.Contains(t, l.st, uint64(3), "fresh tombstone must survive GC")
+	require.NotContains(t, l.st, uint64(2), "expired entry must be swept")
+	require.NotContains(t, l.st, uint64(4), "expired tombstone must be swept")
 }
 
 func TestStateDecodingError(t *testing.T) {

--- a/flushlog/flushlog_test.go
+++ b/flushlog/flushlog_test.go
@@ -582,6 +582,57 @@ func TestLog_AfterTombstone(t *testing.T) {
 	require.Len(t, broadcasts, 1, "expected exactly one broadcast")
 }
 
+// TestLogDelete_LongLivedEntry asserts that Delete bumps the tombstone's
+// Timestamp to the deletion time when the underlying entry has been
+// refreshed for longer than retention. Without the bump, the tombstone
+// would be swept by GC immediately (Timestamp + retention is already in
+// the past), opening a resurrection window for in-flight refresh
+// broadcasts.
+func TestLogDelete_LongLivedEntry(t *testing.T) {
+	mockClock := clock.NewMock()
+	t1 := mockClock.Now()
+	retention := 24 * time.Hour
+	mockClock.Add(100 * time.Hour)
+	deletionTime := mockClock.Now()
+
+	l := &FlushLog{
+		clock:     mockClock,
+		retention: retention,
+		metrics:   newMetrics(nil),
+		broadcast: func([]byte) {},
+		st: state{
+			1: &pb.MeshFlushLog{
+				FlushLog: &pb.FlushLog{
+					GroupFingerprint: 1,
+					Timestamp:        t1, // original flush, well outside retention
+				},
+				ExpiresAt: deletionTime.Add(retention), // recently refreshed
+			},
+		},
+	}
+
+	err := l.Delete(1)
+	require.NoError(t, err)
+
+	tomb, ok := l.st[1]
+	require.True(t, ok, "tombstone must be retained in state")
+	require.True(t, tomb.ExpiresAt.IsZero(), "ExpiresAt must be zero")
+	require.Equal(t, deletionTime, tomb.FlushLog.Timestamp, "Timestamp must be bumped to deletion time")
+
+	// GC right after delete must not sweep the tombstone.
+	n, err := l.GC()
+	require.NoError(t, err)
+	require.Equal(t, 0, n, "tombstone must not be swept immediately after delete")
+	require.Contains(t, l.st, uint64(1))
+
+	// Advance past retention from deletion; tombstone is now eligible for sweep.
+	mockClock.Add(retention + time.Second)
+	n, err = l.GC()
+	require.NoError(t, err)
+	require.Equal(t, 1, n, "tombstone must be swept once retention since delete has elapsed")
+	require.NotContains(t, l.st, uint64(1))
+}
+
 // TestLogGC_Tombstones asserts GC retains tombstones until
 // FlushLog.Timestamp + retention has passed, then sweeps them.
 func TestLogGC_Tombstones(t *testing.T) {

--- a/flushlog/flushlog_test.go
+++ b/flushlog/flushlog_test.go
@@ -582,6 +582,45 @@ func TestLog_AfterTombstone(t *testing.T) {
 	require.Len(t, broadcasts, 1, "expected exactly one broadcast")
 }
 
+// TestQuery_PointerStability asserts that a *pb.FlushLog returned by
+// Query is not mutated by a subsequent Delete. Query releases the read
+// lock before the caller dereferences fields; mutating the in-map
+// pointer (rather than replacing it) would race on time.Time's
+// multi-word value.
+func TestQuery_PointerStability(t *testing.T) {
+	mockClock := clock.NewMock()
+	t1 := mockClock.Now()
+
+	l := &FlushLog{
+		clock:     mockClock,
+		retention: 24 * time.Hour,
+		metrics:   newMetrics(nil),
+		broadcast: func([]byte) {},
+		st: state{
+			1: &pb.MeshFlushLog{
+				FlushLog: &pb.FlushLog{
+					GroupFingerprint: 1,
+					Timestamp:        t1,
+				},
+				ExpiresAt: t1.Add(time.Hour),
+			},
+		},
+	}
+
+	entries, err := l.Query(1)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	held := entries[0]
+	require.Equal(t, t1, held.Timestamp)
+
+	// Advance the clock and delete. This would bump the in-map Timestamp
+	// to the new now if Delete mutated the existing pointer in place.
+	mockClock.Add(100 * time.Hour)
+	require.NoError(t, l.Delete(1))
+
+	require.Equal(t, t1, held.Timestamp, "pointer returned by Query must not be mutated by Delete")
+}
+
 // TestLogDelete_LongLivedEntry asserts that Delete bumps the tombstone's
 // Timestamp to the deletion time when the underlying entry has been
 // refreshed for longer than retention. Without the bump, the tombstone

--- a/flushlog/flushlog_test.go
+++ b/flushlog/flushlog_test.go
@@ -655,10 +655,10 @@ func TestLogGC_Tombstones(t *testing.T) {
 		retention: retention,
 		metrics:   newMetrics(nil),
 		st: state{
-			1: entry(1, now, now.Add(time.Second)),                      // entry, ExpiresAt still in future — keep
-			2: entry(2, now.Add(-2*time.Hour), now.Add(-time.Second)),   // entry, expired — sweep
-			3: entry(3, now, time.Time{}),                               // tombstone, Timestamp+retention in future — keep
-			4: entry(4, now.Add(-2*retention), time.Time{}),             // tombstone, Timestamp+retention in past — sweep
+			1: entry(1, now, now.Add(time.Second)),                    // entry, ExpiresAt still in future — keep
+			2: entry(2, now.Add(-2*time.Hour), now.Add(-time.Second)), // entry, expired — sweep
+			3: entry(3, now, time.Time{}),                             // tombstone, Timestamp+retention in future — keep
+			4: entry(4, now.Add(-2*retention), time.Time{}),           // tombstone, Timestamp+retention in past — sweep
 		},
 	}
 


### PR DESCRIPTION
## Summary

A `flushLog` entry can be re-gossiped indefinitely between alertmanager nodes when a delete tombstone (zero `ExpiresAt`) and a refresh broadcast with the same `Timestamp` are in flight simultaneously.

`FlushLog.Delete` removed the entry from local state and broadcast the tombstone. A still-in-flight refresh broadcast then arrived at a node that had already processed the tombstone, hit the `!ok` branch in `state.merge`'s entry-path, and resurrected the entry. The resurrected entry was re-broadcast, the tombstone re-deleted it on the next round, and the cycle continued.

## Fix

Retain tombstones in `state` (with a Timestamp at least as recent as the deleted entry's) instead of removing them. The same-or-newer-Timestamp check in `state.merge`'s entry-path then rejects stale refresh broadcasts. Five touchpoints in `flushlog/flushlog.go` agree on the convention: `state.merge` overwrites rather than deletes; `Delete` marks `ExpiresAt = time.Time{}` in place and bumps `FlushLog.Timestamp` to `max(original, l.now())` so the GC sweep anchor reflects when the tombstone was created (necessary for long-firing alerts whose original Timestamp is well outside `retention`); `GC` sweeps tombstones at `Timestamp + retention`; `Log` ignores a tombstone `prevle` so the new flush uses the fresh `flushTime`; `Query` hides tombstones via `ErrNotFound`. No proto changes — wire-compatible with peers running older code.

## Test plan

- [x] `go test ./flushlog/... ./dispatch/...` passes.
- [x] New tests cover resurrection prevention, gossip propagation return values, tombstone GC, long-lived-entry deletion, and `Query`/`Log` post-tombstone behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cluster gossip merge/delete/GC logic and changes on-wire convergence behavior; bugs could cause stale flushlog entries or delayed deletions, though the change is localized and heavily tested.
> 
> **Overview**
> Prevents flushlog gossip “ping-pong” by **retaining delete tombstones in local state** (instead of removing entries) and making `state.merge` treat tombstones as authoritative based on `FlushLog.Timestamp`.
> 
> Updates `Delete` to **replace** the stored entry with a fresh tombstone (avoiding pointer mutation races) and to bump the tombstone timestamp to `max(original, now)` so GC retention is anchored to deletion time; updates `GC`, `Log`, and `Query` to handle tombstones consistently (hide from queries, allow fresh logs to override tombstones, and sweep tombstones after `Timestamp + retention`).
> 
> Adds/adjusts tests covering resurrection prevention, gossip propagation decisions, tombstone GC behavior, long-lived entry deletion, and `Query`/`Log` behavior around tombstones.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6e6c5b8138ffa0511db0353fcede8f104c3b904. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->