### PR TITLE
Fix memory leak when alerts in memMarker are not deleted after they resolve

### DIFF
--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -84,6 +84,7 @@ type Dispatcher struct {
 	route   *Route
 	alerts  provider.Alerts
 	stage   notify.Stage
+	marker  types.Marker
 	metrics *DispatcherMetrics
 	limits  Limits
 
@@ -134,6 +135,7 @@ func NewDispatcher(
 		alerts:       ap,
 		stage:        s,
 		route:        r,
+		marker:       mk,
 		timeout:      to,
 		logger:       log.With(l, "component", "dispatcher"),
 		metrics:      m,
@@ -368,7 +370,7 @@ func (d *Dispatcher) processAlert(dispatchLink trace.Link, alert *types.Alert, r
 		return
 	}
 
-	ag = newAggrGroup(d.ctx, groupLabels, route, d.timeout, d.logger, d.timerFactory)
+	ag = newAggrGroup(d.ctx, groupLabels, route, d.timeout, d.logger, d.timerFactory, d.marker)
 	routeGroups[fp] = ag
 	d.aggrGroupsNum++
 	d.metrics.aggrGroups.Inc()
@@ -426,6 +428,7 @@ type aggrGroup struct {
 	opts     *RouteOpts
 	logger   log.Logger
 	routeKey string
+	marker   types.Marker
 
 	alerts  *store.Alerts
 	ctx     context.Context
@@ -439,7 +442,7 @@ type aggrGroup struct {
 }
 
 // newAggrGroup returns a new aggregation group.
-func newAggrGroup(ctx context.Context, labels model.LabelSet, r *Route, to func(time.Duration) time.Duration, logger log.Logger, timerFactory TimerFactory) *aggrGroup {
+func newAggrGroup(ctx context.Context, labels model.LabelSet, r *Route, to func(time.Duration) time.Duration, logger log.Logger, timerFactory TimerFactory, marker types.Marker) *aggrGroup {
 	if to == nil {
 		to = func(d time.Duration) time.Duration { return d }
 	}
@@ -448,6 +451,7 @@ func newAggrGroup(ctx context.Context, labels model.LabelSet, r *Route, to func(
 		routeKey: r.Key(),
 		opts:     &r.RouteOpts,
 		timeout:  to,
+		marker:   marker,
 		alerts:   store.NewAlerts(),
 		done:     make(chan struct{}),
 	}
@@ -590,6 +594,15 @@ func (ag *aggrGroup) flush(ctx context.Context, nf notifyFunc) {
 		// Delete resolved alerts after 3 * group_interval to avoid persistent notification failures
 		// causing unbounded memory growth.
 		ag.alerts.DeleteIfStale(resolvedSlice, ag.opts.GroupInterval*3)
+	}
+
+	// Delete resolved alerts from the marker to prevent orphaned entries: the
+	// mem.Alerts GC fires periodically and deletes marker entries, but the next
+	// flush can re-create them via SetInhibited and never cleans them up.
+	if ag.marker != nil {
+		for _, a := range resolvedSlice {
+			ag.marker.Delete(a.Fingerprint())
+		}
 	}
 }
 

--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -584,24 +584,25 @@ func (ag *aggrGroup) flush(ctx context.Context, nf notifyFunc) {
 
 	level.Debug(l).Log("msg", "flushing", "alerts", fmt.Sprintf("%v", alertsSlice))
 
+	var deleted []model.Fingerprint
 	if nf(ctx, alertsSlice...) {
 		// Delete all resolved alerts as we just sent a notification for them,
 		// and we don't want to send another one. However, we need to make sure
 		// that each resolved alert has not fired again during the flush as then
 		// we would delete an active alert thinking it was resolved.
-		ag.alerts.DeleteIfNotModified(resolvedSlice)
+		deleted = ag.alerts.DeleteIfNotModified(resolvedSlice)
 	} else {
 		// Delete resolved alerts after 3 * group_interval to avoid persistent notification failures
 		// causing unbounded memory growth.
-		ag.alerts.DeleteIfStale(resolvedSlice, ag.opts.GroupInterval*3)
+		deleted = ag.alerts.DeleteIfStale(resolvedSlice, ag.opts.GroupInterval*3)
 	}
 
 	// Delete resolved alerts from the marker to prevent orphaned entries: the
 	// mem.Alerts GC fires periodically and deletes marker entries, but the next
 	// flush can re-create them via SetInhibited and never cleans them up.
 	if ag.marker != nil {
-		for _, a := range resolvedSlice {
-			ag.marker.Delete(a.Fingerprint())
+		for _, fp := range deleted {
+			ag.marker.Delete(fp)
 		}
 	}
 }

--- a/dispatch/dispatch_test.go
+++ b/dispatch/dispatch_test.go
@@ -138,7 +138,7 @@ func TestAggrGroup(t *testing.T) {
 	}
 
 	// Test regular situation where we wait for group_wait to send out alerts.
-	ag := newAggrGroup(context.Background(), lset, route, nil, log.NewNopLogger(), standardTimerFactory)
+	ag := newAggrGroup(context.Background(), lset, route, nil, log.NewNopLogger(), standardTimerFactory, nil)
 	go ag.run(ntfy)
 
 	ag.insert(a1)
@@ -192,7 +192,7 @@ func TestAggrGroup(t *testing.T) {
 	// immediate flushing.
 	// Finally, set all alerts to be resolved. After successful notify the aggregation group
 	// should empty itself.
-	ag = newAggrGroup(context.Background(), lset, route, nil, log.NewNopLogger(), standardTimerFactory)
+	ag = newAggrGroup(context.Background(), lset, route, nil, log.NewNopLogger(), standardTimerFactory, nil)
 	go ag.run(ntfy)
 
 	ag.insert(a1)
@@ -714,4 +714,75 @@ type limits struct {
 
 func (l limits) MaxNumberOfAggregationGroups() int {
 	return l.groups
+}
+
+// TestAggrGroupFlushDeletesMarkerEntries verifies that flush() cleans up marker
+// entries for resolved alerts, preventing memory leaks from orphaned marker entries.
+func TestAggrGroupFlushDeletesMarkerEntries(t *testing.T) {
+	lset := model.LabelSet{"alertname": "test"}
+	route := &Route{
+		RouteOpts: RouteOpts{
+			Receiver:       "test",
+			GroupBy:        map[model.LabelName]struct{}{},
+			GroupInterval:  time.Millisecond,
+			RepeatInterval: time.Hour,
+		},
+	}
+
+	newGroup := func() (types.Marker, *aggrGroup) {
+		m := types.NewMarker(prometheus.NewRegistry())
+		return m, newAggrGroup(context.Background(), lset, route, nil, log.NewNopLogger(), standardTimerFactory, m)
+	}
+
+	// nfWithInhibit simulates MuteStage calling SetInhibited unconditionally for
+	// every alert, as the real pipeline does, then returns the given success value.
+	nfWithInhibit := func(marker types.Marker, success bool) notifyFunc {
+		return func(_ context.Context, alerts ...*types.Alert) bool {
+			for _, a := range alerts {
+				marker.SetInhibited(a.Fingerprint())
+			}
+			return success
+		}
+	}
+
+	resolved := func(updatedAt time.Time) *types.Alert {
+		return &types.Alert{
+			Alert:     model.Alert{Labels: lset, StartsAt: updatedAt.Add(-time.Minute), EndsAt: updatedAt},
+			UpdatedAt: updatedAt,
+		}
+	}
+
+	t.Run("resolved alert removed on success", func(t *testing.T) {
+		marker, ag := newGroup()
+		require.NoError(t, ag.alerts.Set(resolved(time.Now().Add(-time.Second))))
+		ag.flush(context.Background(), nfWithInhibit(marker, true))
+		require.Equal(t, 0, marker.Count())
+	})
+
+	t.Run("stale resolved alert removed on notification failure", func(t *testing.T) {
+		marker, ag := newGroup()
+		require.NoError(t, ag.alerts.Set(resolved(time.Now().Add(-time.Hour))))
+		ag.flush(context.Background(), nfWithInhibit(marker, false))
+		require.Equal(t, 0, marker.Count())
+	})
+
+	t.Run("active alert keeps its marker entry", func(t *testing.T) {
+		marker, ag := newGroup()
+		require.NoError(t, ag.alerts.Set(&types.Alert{
+			Alert:     model.Alert{Labels: lset, StartsAt: time.Now().Add(-time.Minute), EndsAt: time.Now().Add(time.Hour)},
+			UpdatedAt: time.Now().Add(-time.Minute),
+		}))
+		ag.flush(context.Background(), nfWithInhibit(marker, true))
+		require.Equal(t, 1, marker.Count())
+	})
+
+	t.Run("GC race: entry re-created by flush after GC deletion is cleaned up", func(t *testing.T) {
+		marker, ag := newGroup()
+		a := resolved(time.Now().Add(-time.Second))
+		require.NoError(t, ag.alerts.Set(a))
+		marker.SetInhibited(a.Fingerprint())
+		marker.Delete(a.Fingerprint())
+		ag.flush(context.Background(), nfWithInhibit(marker, true))
+		require.Equal(t, 0, marker.Count())
+	})
 }

--- a/dispatch/dispatch_test.go
+++ b/dispatch/dispatch_test.go
@@ -785,4 +785,37 @@ func TestAggrGroupFlushDeletesMarkerEntries(t *testing.T) {
 		ag.flush(context.Background(), nfWithInhibit(marker, true))
 		require.Equal(t, 0, marker.Count())
 	})
+
+	t.Run("re-fired alert during flush keeps its marker entry", func(t *testing.T) {
+		marker, ag := newGroup()
+
+		// Two resolved alerts with different fingerprints.
+		a1 := resolved(time.Now().Add(-time.Second))
+		a2 := &types.Alert{
+			Alert:     model.Alert{Labels: model.LabelSet{"alertname": "test2"}, StartsAt: time.Now().Add(-time.Minute), EndsAt: time.Now().Add(-time.Second)},
+			UpdatedAt: time.Now().Add(-time.Second),
+		}
+		require.NoError(t, ag.alerts.Set(a1))
+		require.NoError(t, ag.alerts.Set(a2))
+
+		// nf simulates a2 re-firing during notification delivery.
+		nf := func(_ context.Context, alerts ...*types.Alert) bool {
+			for _, a := range alerts {
+				marker.SetInhibited(a.Fingerprint())
+			}
+			refired := *a2
+			refired.EndsAt = time.Now().Add(time.Hour)
+			refired.UpdatedAt = time.Now()
+			require.NoError(t, ag.alerts.Set(&refired))
+			return true
+		}
+
+		ag.flush(context.Background(), nf)
+
+		// a1 was deleted, marker entry gone. a2 re-fired, marker entry kept.
+		require.Equal(t, 1, marker.Count())
+		_, inhibited := marker.Inhibited(a2.Fingerprint())
+		require.False(t, inhibited)
+		require.True(t, marker.Active(a2.Fingerprint()))
+	})
 }

--- a/store/store.go
+++ b/store/store.go
@@ -115,16 +115,17 @@ func (a *Alerts) Set(alert *types.Alert) error {
 }
 
 // DeleteIfNotModified deletes the slice of Alerts from the store if not
-// modified.
-func (a *Alerts) DeleteIfNotModified(alerts types.AlertSlice) {
+// modified. It returns the fingerprints of alerts that were actually deleted.
+func (a *Alerts) DeleteIfNotModified(alerts types.AlertSlice) []model.Fingerprint {
 	a.Lock()
 	defer a.Unlock()
-	a.deleteIfNotModified(alerts)
+	return a.deleteIfNotModified(alerts)
 }
 
 // DeleteIfStale deletes the slice of Alerts from the store if the time since
-// the last update is greater than or equal to the given TTL.
-func (a *Alerts) DeleteIfStale(alerts types.AlertSlice, ttl time.Duration) {
+// the last update is greater than or equal to the given TTL. It returns the
+// fingerprints of alerts that were actually deleted.
+func (a *Alerts) DeleteIfStale(alerts types.AlertSlice, ttl time.Duration) []model.Fingerprint {
 	a.Lock()
 	defer a.Unlock()
 
@@ -136,18 +137,21 @@ func (a *Alerts) DeleteIfStale(alerts types.AlertSlice, ttl time.Duration) {
 		}
 	}
 
-	a.deleteIfNotModified(stale)
+	return a.deleteIfNotModified(stale)
 }
 
 // deleteIfNotModified deletes alerts from the store whose UpdatedAt has not changed.
 // Not thread-safe. The caller must hold the lock.
-func (a *Alerts) deleteIfNotModified(alerts types.AlertSlice) {
+func (a *Alerts) deleteIfNotModified(alerts types.AlertSlice) []model.Fingerprint {
+	var deleted []model.Fingerprint
 	for _, alert := range alerts {
 		fp := alert.Fingerprint()
 		if other, ok := a.c[fp]; ok && alert.UpdatedAt.Equal(other.UpdatedAt) {
 			delete(a.c, fp)
+			deleted = append(deleted, fp)
 		}
 	}
+	return deleted
 }
 
 // List returns a slice of Alerts currently held in memory.

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -51,10 +51,11 @@ func TestDeleteIfNotModified(t *testing.T) {
 		require.NoError(t, a.Set(a1))
 
 		// a1 should be deleted as it has not been modified.
-		a.DeleteIfNotModified(types.AlertSlice{a1})
+		deleted := a.DeleteIfNotModified(types.AlertSlice{a1})
 		got, err := a.Get(a1.Fingerprint())
 		require.Equal(t, ErrNotFound, err)
 		require.Nil(t, got)
+		require.Equal(t, []model.Fingerprint{a1.Fingerprint()}, deleted)
 	})
 
 	t.Run("modified alert should not be deleted", func(t *testing.T) {
@@ -80,11 +81,12 @@ func TestDeleteIfNotModified(t *testing.T) {
 			UpdatedAt: time.Now().Add(-time.Second),
 		}
 		require.True(t, a2.UpdatedAt.Before(a1.UpdatedAt))
-		a.DeleteIfNotModified(types.AlertSlice{a2})
+		deleted := a.DeleteIfNotModified(types.AlertSlice{a2})
 		// a1 should not be deleted.
 		got, err := a.Get(a1.Fingerprint())
 		require.NoError(t, err)
 		require.Equal(t, a1, got)
+		require.Empty(t, deleted)
 
 		// Make another copy of a1 that is older, but do not put it.
 		// We want to make sure a2 is not deleted here either.
@@ -97,11 +99,12 @@ func TestDeleteIfNotModified(t *testing.T) {
 			UpdatedAt: time.Now().Add(time.Second),
 		}
 		require.True(t, a3.UpdatedAt.After(a1.UpdatedAt))
-		a.DeleteIfNotModified(types.AlertSlice{a3})
+		deleted = a.DeleteIfNotModified(types.AlertSlice{a3})
 		// a1 should not be deleted.
 		got, err = a.Get(a1.Fingerprint())
 		require.NoError(t, err)
 		require.Equal(t, a1, got)
+		require.Empty(t, deleted)
 	})
 
 	t.Run("should not delete other alerts", func(t *testing.T) {
@@ -126,11 +129,12 @@ func TestDeleteIfNotModified(t *testing.T) {
 		require.NoError(t, a.Set(a2))
 
 		// Deleting a1 should not delete a2.
-		a.DeleteIfNotModified(types.AlertSlice{a1})
+		deleted := a.DeleteIfNotModified(types.AlertSlice{a1})
 		// a1 should be deleted.
 		got, err := a.Get(a1.Fingerprint())
 		require.Equal(t, ErrNotFound, err)
 		require.Nil(t, got)
+		require.Equal(t, []model.Fingerprint{a1.Fingerprint()}, deleted)
 		// a2 should not be deleted.
 		got, err = a.Get(a2.Fingerprint())
 		require.NoError(t, err)
@@ -156,10 +160,11 @@ func TestDeleteIfStale(t *testing.T) {
 		alert := newAlert("foo", "bar", staleTime)
 		require.NoError(t, a.Set(alert))
 
-		a.DeleteIfStale(types.AlertSlice{alert}, ttl)
+		deleted := a.DeleteIfStale(types.AlertSlice{alert}, ttl)
 
 		_, err := a.Get(alert.Fingerprint())
 		require.Equal(t, ErrNotFound, err)
+		require.Equal(t, []model.Fingerprint{alert.Fingerprint()}, deleted)
 	})
 
 	t.Run("fresh alert is kept", func(t *testing.T) {
@@ -167,11 +172,12 @@ func TestDeleteIfStale(t *testing.T) {
 		alert := newAlert("foo", "bar", freshTime)
 		require.NoError(t, a.Set(alert))
 
-		a.DeleteIfStale(types.AlertSlice{alert}, ttl)
+		deleted := a.DeleteIfStale(types.AlertSlice{alert}, ttl)
 
 		got, err := a.Get(alert.Fingerprint())
 		require.NoError(t, err)
 		require.Equal(t, alert, got)
+		require.Empty(t, deleted)
 	})
 
 	t.Run("modified alert is not deleted even if stale", func(t *testing.T) {
@@ -180,11 +186,12 @@ func TestDeleteIfStale(t *testing.T) {
 		newer := newAlert("foo", "bar", freshTime)
 		require.NoError(t, a.Set(newer))
 
-		a.DeleteIfStale(types.AlertSlice{old}, ttl)
+		deleted := a.DeleteIfStale(types.AlertSlice{old}, ttl)
 
 		got, err := a.Get(newer.Fingerprint())
 		require.NoError(t, err)
 		require.Equal(t, newer, got)
+		require.Empty(t, deleted)
 	})
 
 	t.Run("only stale alerts are deleted, fresh ones are kept", func(t *testing.T) {
@@ -194,13 +201,14 @@ func TestDeleteIfStale(t *testing.T) {
 		require.NoError(t, a.Set(stale))
 		require.NoError(t, a.Set(fresh))
 
-		a.DeleteIfStale(types.AlertSlice{stale, fresh}, ttl)
+		deleted := a.DeleteIfStale(types.AlertSlice{stale, fresh}, ttl)
 
 		_, err := a.Get(stale.Fingerprint())
 		require.Equal(t, ErrNotFound, err)
 		got, err := a.Get(fresh.Fingerprint())
 		require.NoError(t, err)
 		require.Equal(t, fresh, got)
+		require.Equal(t, []model.Fingerprint{stale.Fingerprint()}, deleted)
 	})
 }
 


### PR DESCRIPTION
### Description

The [`types.memMarker`](https://github.com/grafana/prometheus-alertmanager/blob/0aa713f88f2cbaf95dafbbcbb2b82246bf2b8af7/types/types.go#L106-L110) struct is responsible for tracking the suppression state of every alert, recording whether a given alert is _unprocessed_, _suppressed_ (inhibited/silenced), or _active_. It holds a map of alert fingerprints to `*AlertStatus`, which can grow boundlessly.

Two structs that have alert stores to be aware of here:
- [`mem.Alerts`](https://github.com/grafana/prometheus-alertmanager/blob/0aa713f88f2cbaf95dafbbcbb2b82246bf2b8af7/provider/mem/mem.go#L33-L47): it receives alerts from POSTs and gossips
- [`aggrGroup`](https://github.com/grafana/prometheus-alertmanager/blob/0aa713f88f2cbaf95dafbbcbb2b82246bf2b8af7/dispatch/dispatch.go#L421-L439): aggregation groups also keep alerts in memory

The [`marker.Delete()`](https://github.com/grafana/prometheus-alertmanager/blob/0aa713f88f2cbaf95dafbbcbb2b82246bf2b8af7/types/types.go#L218-L224) method removes entries from the `memMarker`, but it's only called in the [GC callback](https://github.com/grafana/prometheus-alertmanager/blob/0aa713f88f2cbaf95dafbbcbb2b82246bf2b8af7/provider/mem/mem.go#L103-L110) of `mem.Alerts`, which runs every 30 minutes by default.

Each aggregation group maintains [its own separate alert store](https://github.com/grafana/prometheus-alertmanager/blob/0aa713f88f2cbaf95dafbbcbb2b82246bf2b8af7/dispatch/dispatch.go#L430) with no GC routine. When [`aggrGroup.flush()`](https://github.com/grafana/prometheus-alertmanager/blob/0aa713f88f2cbaf95dafbbcbb2b82246bf2b8af7/dispatch/dispatch.go#L554-L594) removes a resolved alert from its own alert store via [`DeleteIfNotModified()`](https://github.com/grafana/prometheus-alertmanager/blob/0aa713f88f2cbaf95dafbbcbb2b82246bf2b8af7/dispatch/dispatch.go#L588) or [`DeleteIfStale()`](https://github.com/grafana/prometheus-alertmanager/blob/0aa713f88f2cbaf95dafbbcbb2b82246bf2b8af7/dispatch/dispatch.go#L592), it never calls `marker.Delete()`, leaving the marker entry orphaned.

This becomes a leak when the `mem.Alerts` GC fires between two flush cycles:
1. Alert `foo` resolves (present in both `mem.Alerts`, `aggrGroup`, and possibly the `marker`)
2. `mem.Alerts` GC fires, removes `foo` from `mem.Alerts` and the `marker` (if it's there)
3. `aggrGroup.flush()` runs, [`SetInhibited(foo)`](https://github.com/grafana/prometheus-alertmanager/blob/0aa713f88f2cbaf95dafbbcbb2b82246bf2b8af7/inhibit/inhibit.go#L139-L143) is called, entry for `foo` (re-)created
4. `DeleteIfNotModified()` or `DeleteIfStale()` remove `foo` from `aggrGroup.alerts`
5. `marker.Delete(foo)` is never called again, leak!

This PR fixes this memory leak by calling `marker.Delete()` in the aggregation groups with the resolved alerts slice after calling `DeleteIfNotModified()`/`DeleteIfStale()`, avoiding orphaned entries in `memMarker`.

### Testing

I tested this fix using two Alertmanagers (with/without the fix) and a script that sends resolved alerts with unique fingerprints. I used a GC interval of 2 seconds and a `group_wait=10s` to accumulate memory quickly.

<details>
<summary><code>alertmanager_marked_alerts</code> grows linearly in the leaky Alertmanager, but stays constant in the fixed one</summary>

<img width="1736" height="689" alt="image" src="https://github.com/user-attachments/assets/f14c56c1-dd8d-49ba-9f2d-b94164838cd4" />
</details>

<details>
<summary>Memory grows boundlessly in the leaky Alertmanager, but not in the one with the fix</summary>

<img width="1746" height="808" alt="localhost_9090_query_g0 expr=process_resident_memory_bytes g0 show_tree=0 g0 tab=graph g0 range_input=1h g0 res_type=auto g0 res_density=medium g0 display_mode=lines g0 show_exemplars=0" src="https://github.com/user-attachments/assets/1af5c3db-880d-4d45-a641-9195280caba9" />
</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes alert lifecycle cleanup by threading `types.Marker` into aggregation groups and altering `store.Alerts` deletion APIs to return deleted fingerprints; mistakes could cause incorrect marker state or missed notifications, but scope is limited to dispatch/store internals.
> 
> **Overview**
> Fixes a memory leak where suppression `marker` entries could be re-created during `aggrGroup.flush()` and never cleaned up after alerts resolve.
> 
> `Dispatcher` now passes a `types.Marker` into each `aggrGroup`, and `flush()` deletes marker entries for any resolved alerts actually removed from the group store. To support this, `store.Alerts.DeleteIfNotModified`/`DeleteIfStale` now return the fingerprints they deleted, and tests were updated plus a new suite added to cover success/failure, GC-race, and re-fire scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 499e29f279f9983e87684a4374d55c185c56968f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->