### PR TITLE
ci: add actionlint pre-merge linting

### DIFF
--- a/.github/workflows/actionlint-format.txt
+++ b/.github/workflows/actionlint-format.txt
@@ -1,0 +1,66 @@
+{
+    "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+    "version": "2.1.0",
+    "runs": [
+        {
+            "tool": {
+                "driver": {
+                    "name": "GitHub Actions lint",
+                    "version": {{ getVersion | json }},
+                    "informationUri": "https://github.com/rhysd/actionlint",
+                    "rules": [
+                        {{$first := true}}
+                        {{range $ := allKinds }}
+                            {{if $first}}{{$first = false}}{{else}},{{end}}
+                            {
+                                "id": {{json $.Name}},
+                                "name": {{$.Name | toPascalCase | json}},
+                                "defaultConfiguration": {
+                                    "level": "error"
+                                },
+                                "properties": {
+                                    "description": {{json $.Description}},
+                                    "queryURI": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+                                },
+                                "fullDescription": {
+                                    "text": {{json $.Description}}
+                                },
+                                "helpUri": "https://github.com/rhysd/actionlint/blob/main/docs/checks.md"
+                            }
+                        {{end}}
+                    ]
+                }
+            },
+            "results": [
+                {{$first := true}}
+                {{range $ := .}}
+                    {{if $first}}{{$first = false}}{{else}},{{end}}
+                    {
+                        "ruleId": {{json $.Kind}},
+                        "message": {
+                            "text": {{json $.Message}}
+                        },
+                        "locations": [
+                            {
+                                "physicalLocation": {
+                                    "artifactLocation": {
+                                        "uri": {{json $.Filepath}},
+                                        "uriBaseId": "%SRCROOT%"
+                                    },
+                                    "region": {
+                                        "startLine": {{$.Line}},
+                                        "startColumn": {{$.Column}},
+                                        "endColumn": {{$.EndColumn}},
+                                        "snippet": {
+                                            "text": {{json $.Snippet}}
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                {{end}}
+            ]
+        }
+    ]
+}

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -13,6 +13,8 @@ on:
       - .github/workflows/**
       - .github/actions/**
       - .github/actionlint.yaml
+  merge_group:
+    types: [checks_requested]
 
 permissions: {}
 

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -46,10 +46,14 @@ jobs:
           chmod +x actionlint
 
       - name: Run actionlint
-        run: ./actionlint -format "$(cat .github/workflows/actionlint-format.txt)" | tee results.sarif
+        shell: bash
+        run: |
+          set -o pipefail
+          ./actionlint -format "$(cat .github/workflows/actionlint-format.txt)" | tee results.sarif
 
       - name: Upload SARIF
         if: success() || failure()
+        continue-on-error: true # SARIF upload requires Code Security on the repo; tolerate when off
         uses: github/codeql-action/upload-sarif@f443b600d91635bebf5b0d9ebc620189c0d6fba5 # v4.30.8
         with:
           sarif_file: results.sarif

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -7,12 +7,14 @@ on:
       - .github/workflows/**
       - .github/actions/**
       - .github/actionlint.yaml
+      - .github/actionlint.yml
   push:
     branches: [main]
     paths:
       - .github/workflows/**
       - .github/actions/**
       - .github/actionlint.yaml
+      - .github/actionlint.yml
   merge_group:
     types: [checks_requested]
 

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -33,20 +33,24 @@ jobs:
       actions: read
       security-events: write
     env:
-      ACTIONLINT_VERSION: 1.7.7
-      CHECKSUM: 023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757
+      ACTIONLINT_VERSION: 1.7.12
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
-      - name: Download actionlint
+      - name: Download and verify actionlint
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          curl -OLXGET "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
-          echo "${CHECKSUM}  actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" | sha256sum -c -
-          tar xzf "actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          ARCHIVE="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          gh release download "v${ACTIONLINT_VERSION}" \
+            --repo rhysd/actionlint \
+            --pattern "${ARCHIVE}"
+          gh attestation verify "${ARCHIVE}" --repo rhysd/actionlint
+          tar xzf "${ARCHIVE}"
           chmod +x actionlint
 
       - name: Run actionlint

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -37,7 +37,7 @@ jobs:
       CHECKSUM: 023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757
     steps:
       - name: Checkout code
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
@@ -58,7 +58,7 @@ jobs:
       - name: Upload SARIF
         if: success() || failure()
         continue-on-error: true # SARIF upload requires Code Security on the repo; tolerate when off
-        uses: github/codeql-action/upload-sarif@f443b600d91635bebf5b0d9ebc620189c0d6fba5 # v4.30.8
+        uses: github/codeql-action/upload-sarif@f52b05f4acaaa234e44466e66d29050e135ea9ef # v4.36.0
         with:
           sarif_file: results.sarif
           category: actionlint

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,56 @@
+name: actionlint
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - .github/workflows/**
+      - .github/actions/**
+      - .github/actionlint.yaml
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/**
+      - .github/actions/**
+      - .github/actionlint.yaml
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      security-events: write
+    env:
+      ACTIONLINT_VERSION: 1.7.7
+      CHECKSUM: 023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Download actionlint
+        run: |
+          set -euo pipefail
+          curl -OLXGET "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          echo "${CHECKSUM}  actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" | sha256sum -c -
+          tar xzf "actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          chmod +x actionlint
+
+      - name: Run actionlint
+        run: ./actionlint -format "$(cat .github/workflows/actionlint-format.txt)" | tee results.sarif
+
+      - name: Upload SARIF
+        if: success() || failure()
+        uses: github/codeql-action/upload-sarif@f443b600d91635bebf5b0d9ebc620189c0d6fba5 # v4.30.8
+        with:
+          sarif_file: results.sarif
+          category: actionlint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           persist-credentials: false
       - run: make clean

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -36,7 +36,7 @@ jobs:
         if: github.repository == 'prometheus/snmp_exporter'
       - name: Get golangci-lint version
         id: golangci-lint-version
-        run: echo "version=$(make print-golangci-lint-version)" >> $GITHUB_OUTPUT
+        run: echo "version=$(make print-golangci-lint-version)" >> "$GITHUB_OUTPUT"
       - name: Lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:

--- a/.github/workflows/mixin.yml
+++ b/.github/workflows/mixin.yml
@@ -11,11 +11,11 @@ jobs:
     permissions: {}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           persist-credentials: false
       - name: install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
         with:
           go-version: 1.25.x
       # pin the mixtool version until https://github.com/monitoring-mixins/mixtool/issues/135 is merged.

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -23,4 +23,3 @@ jobs:
       fail-on-verified: "true"
       fail-on-unverified: "false"
       runs-on: ${{ (!github.event.repository.private || github.repository_owner != 'grafana') && 'ubuntu-latest' || 'ubuntu-arm64-small' }}
-    secrets: inherit


### PR DESCRIPTION
## Summary

Adds pre-merge `actionlint` for GitHub Actions workflows. Triggers when files under `.github/workflows/`, `.github/actions/`, or `.github/actionlint.yaml` change.

Zizmor is intentionally not included — the grafana org already runs it on every PR via a required workflow.

Also includes:

- Drop `secrets: inherit` from `trufflehog.yml`. The called reusable workflow declares no secret inputs (and references none in its body), so the inherit is a no-op. Removal clears a zizmor `secrets-inherit` MEDIUM finding.
- SHA-pin unpinned action refs in `mixin.yml` and `ci.yml` (`actions/checkout@v3`, `actions/setup-go@v2`). Resolves zizmor `unpinned-uses` HIGH findings under the org's strict policy.
- Quote `$GITHUB_OUTPUT` redirect in `golangci-lint.yml` (shellcheck SC2086).

Note: this repo is a fork of upstream `prometheus/alertmanager`. The mixin/ci workflow edits may need re-applying on next vendor sync.

## Test plan

- [x] `actionlint` passes locally
- [x] `zizmor` passes locally with `--min-severity high` (was failing with 3 HIGH findings prior to the SHA-pin commit)
- [ ] `actionlint` CI job is green on this PR
- [ ] Org `zizmor` job is green on this PR
- [ ] SARIF results visible in the repo's code-scanning tab

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI workflow definitions and supply-chain hygiene; no application runtime, auth, or data paths are modified.
> 
> **Overview**
> Adds a dedicated **`actionlint`** workflow that runs on PRs, `main` pushes, and merge groups when `.github/workflows/**`, `.github/actions/**`, or actionlint config changes. It downloads a pinned **actionlint** release with **gh attestation verify**, emits SARIF via a new **actionlint-format.txt** template, and uploads results with **codeql-action/upload-sarif** (best-effort if code scanning is off).
> 
> Hardens existing workflows for org security linting: **SHA-pins** `actions/checkout` and `actions/setup-go` in **ci.yml** and **mixin.yml**, removes unused **`secrets: inherit`** from **trufflehog.yml**, and quotes **`$GITHUB_OUTPUT`** in **golangci-lint.yml**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c2b5f9a6963013ffd5f54403a7dd341138bdcdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->