### PR TITLE
Add size limit to nflog snapshot

### DIFF
--- a/nflog/nflog.go
+++ b/nflog/nflog.go
@@ -592,6 +592,11 @@ func (l *Log) loadSnapshot(r io.Reader) error {
 	l.mtx.Lock()
 	l.st = st
 	l.size = st.sizeBytes()
+	// A snapshot loaded on startup may already exceed the limit (e.g. it predates
+	// the limit, or grew while the limit was unset), so trim it now rather than
+	// waiting for the next local write.
+	l.evictToLimit()
+	l.metrics.size.Set(float64(l.size))
 	l.mtx.Unlock()
 
 	return nil
@@ -644,6 +649,10 @@ func (l *Log) Merge(b []byte) error {
 			level.Debug(l.logger).Log("msg", "gossiping new entry", "entry", e)
 		}
 	}
+	// Entries also arrive via Merge from peers, not just local Log writes, so
+	// enforce the size limit here as well. Otherwise the log could grow past the
+	// limit on a node that rarely writes locally.
+	l.evictToLimit()
 	l.metrics.size.Set(float64(l.size))
 	return nil
 }

--- a/nflog/nflog.go
+++ b/nflog/nflog.go
@@ -86,25 +86,19 @@ type Log struct {
 
 	// For now we only store the most recently added log entry.
 	// The key is a serialized concatenation of group key and receiver.
-	mtx sync.RWMutex
-	st  state
-	// size is the running sum of the marshaled sizes of all entries in st, used to
-	// enforce Limits.MaxSizeBytes without recomputing the whole state on each write.
-	size               int
+	mtx                sync.RWMutex
+	st                 state
 	broadcast          func([]byte)
 	isReliableDelivery func([]byte) bool
 }
 
 // Limits contains the limits for the notification log.
 type Limits struct {
-	// MaxSizeBytes limits the total marshaled size of the notification log in
-	// bytes. If nil, or the returned value is negative or 0, there is no limit.
-	//
-	// When recording a notification would push the log over the limit, existing
-	// entries are evicted until it fits again: resolved entries first, then oldest
-	// by last-notification time. Because the notification has already been sent by
-	// the time it is logged, an evicted group is at worst re-notified later (a
-	// duplicate), never missed.
+	// MaxSizeBytes limits the serialized size (in bytes) of the notification log
+	// used for snapshots and state replication. When it is exceeded, the
+	// lowest-priority entries (resolved and oldest first) are omitted from the
+	// serialized copy. The in-memory log is never trimmed. Negative or 0 means no
+	// limit.
 	MaxSizeBytes func() int
 }
 
@@ -122,8 +116,7 @@ type metrics struct {
 	propagatedMessagesTotal prometheus.Counter
 	maintenanceTotal        prometheus.Counter
 	maintenanceErrorsTotal  prometheus.Counter
-	size                    prometheus.Gauge
-	entriesEvictedTotal     prometheus.Counter
+	snapshotEntriesDropped  prometheus.Counter
 }
 
 func newMetrics(r prometheus.Registerer) *metrics {
@@ -171,13 +164,9 @@ func newMetrics(r prometheus.Registerer) *metrics {
 		Name: "alertmanager_nflog_gossip_messages_propagated_total",
 		Help: "Number of received gossip messages that have been further gossiped.",
 	})
-	m.size = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "alertmanager_nflog_size_bytes",
-		Help: "Current total marshaled size of the notification log in bytes.",
-	})
-	m.entriesEvictedTotal = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "alertmanager_nflog_entries_evicted_total",
-		Help: "Number of notification log entries evicted (oldest first) to keep the log within the configured maximum size.",
+	m.snapshotEntriesDropped = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "alertmanager_nflog_snapshot_entries_dropped_total",
+		Help: "Number of notification log entries omitted from a serialized snapshot because it would exceed the configured maximum size.",
 	})
 
 	if r != nil {
@@ -191,8 +180,7 @@ func newMetrics(r prometheus.Registerer) *metrics {
 			m.propagatedMessagesTotal,
 			m.maintenanceTotal,
 			m.maintenanceErrorsTotal,
-			m.size,
-			m.entriesEvictedTotal,
+			m.snapshotEntriesDropped,
 		)
 	}
 	return m
@@ -208,36 +196,20 @@ func (s state) clone() state {
 	return c
 }
 
-// merge stores the entry if it is newer than the existing one for its key. It
-// returns whether the entry was stored (used to decide whether to gossip the
-// message further) and the resulting change (in bytes) to the total marshaled size
-// of the state.
-func (s state) merge(e *pb.MeshEntry, now time.Time) (bool, int) {
+// merge returns true or false whether the MeshEntry was merged or
+// not. This information is used to decide to gossip the message further.
+func (s state) merge(e *pb.MeshEntry, now time.Time) bool {
 	if e.ExpiresAt.Before(now) {
-		return false, 0
+		return false
 	}
 	k := stateKey(string(e.Entry.GroupKey), e.Entry.Receiver)
 
 	prev, ok := s[k]
-	if !ok {
+	if !ok || prev.Entry.Timestamp.Before(e.Entry.Timestamp) {
 		s[k] = e
-		return true, e.Size()
+		return true
 	}
-	if prev.Entry.Timestamp.Before(e.Entry.Timestamp) {
-		s[k] = e
-		return true, e.Size() - prev.Size()
-	}
-	return false, 0
-}
-
-// sizeBytes returns the sum of the marshaled sizes of all entries. This matches
-// the unit tracked incrementally by Log.size.
-func (s state) sizeBytes() int {
-	var n int
-	for _, e := range s {
-		n += e.Size()
-	}
-	return n
+	return false
 }
 
 func (s state) MarshalBinary() ([]byte, error) {
@@ -435,11 +407,10 @@ func (l *Log) Log(r *pb.Receiver, gkey string, firingAlerts, resolvedAlerts []ui
 	l.mtx.Lock()
 	defer l.mtx.Unlock()
 
-	_, isUpdate := l.st[key]
-	if isUpdate {
+	if prevle, ok := l.st[key]; ok {
 		// Entry already exists, only overwrite if timestamp is newer.
 		// This may happen with raciness or clock-drift across AM nodes.
-		if l.st[key].Entry.Timestamp.After(now) {
+		if prevle.Entry.Timestamp.After(now) {
 			return nil
 		}
 	}
@@ -464,61 +435,54 @@ func (l *Log) Log(r *pb.Receiver, gkey string, firingAlerts, resolvedAlerts []ui
 	if err != nil {
 		return err
 	}
-
-	_, delta := l.st.merge(e, l.now())
-	l.size += delta
-
-	// Enforce the size limit by evicting existing entries (resolved first, then
-	// oldest by last-notification time) until the log is within the limit. Evicting
-	// rather than rejecting the new entry keeps the most recently active groups
-	// recorded. The evicted entries are the least likely to be re-notified. The
-	// notification has already been sent by this point, so at worst this re-notifies
-	// an evicted group (a duplicate) later, never a missed notification.
-	l.evictToLimit()
-
-	l.metrics.size.Set(float64(l.size))
+	l.st.merge(e, l.now())
 	l.broadcast(b)
 
 	return nil
 }
 
-// evictToLimit removes entries until the total marshaled size is within
-// Limits.MaxSizeBytes, preferring resolved entries and then the oldest (by last
-// notification time). Caller must hold l.mtx.
-func (l *Log) evictToLimit() {
-	if l.limits.MaxSizeBytes == nil {
-		return
+// marshalStateWithinLimit serializes the log without modifying it, keeping entries
+// in priority order (firing before resolved, newest before oldest) up to
+// Limits.MaxSizeBytes and omitting the rest. Caller must hold l.mtx.
+func (l *Log) marshalStateWithinLimit() ([]byte, error) {
+	max := 0
+	if l.limits.MaxSizeBytes != nil {
+		max = l.limits.MaxSizeBytes()
 	}
-	max := l.limits.MaxSizeBytes()
-	if max <= 0 || l.size <= max {
-		return
+	if max <= 0 {
+		return l.st.MarshalBinary()
 	}
 
-	// Order the evictable keys resolved-first, then oldest-first within each tier.
-	// Evicting a resolved entry (no firing alerts) risks at most a duplicate
-	// resolved notification, whereas evicting a firing entry risks a duplicate page,
-	// so drop the harmless records before the harmful ones.
 	keys := make([]string, 0, len(l.st))
 	for k := range l.st {
 		keys = append(keys, k)
 	}
 	sort.Slice(keys, func(i, j int) bool {
 		ei, ej := l.st[keys[i]].Entry, l.st[keys[j]].Entry
-		ri, rj := len(ei.FiringAlerts) == 0, len(ej.FiringAlerts) == 0
-		if ri != rj {
-			return ri // resolved (no firing alerts) evicted first
+		fi, fj := len(ei.FiringAlerts) > 0, len(ej.FiringAlerts) > 0
+		if fi != fj {
+			return fi // keep firing before resolved
 		}
-		return ei.Timestamp.Before(ej.Timestamp) // then oldest-first
+		return ei.Timestamp.After(ej.Timestamp) // keep newest before oldest
 	})
 
+	var buf bytes.Buffer
+	var dropped int
 	for _, k := range keys {
-		if l.size <= max {
-			break
+		eb, err := marshalMeshEntry(l.st[k])
+		if err != nil {
+			return nil, err
 		}
-		l.size -= l.st[k].Size()
-		delete(l.st, k)
-		l.metrics.entriesEvictedTotal.Inc()
+		if buf.Len()+len(eb) > max {
+			dropped++
+			continue
+		}
+		buf.Write(eb)
 	}
+	if dropped > 0 {
+		l.metrics.snapshotEntriesDropped.Add(float64(dropped))
+	}
+	return buf.Bytes(), nil
 }
 
 // GC implements the Log interface.
@@ -537,12 +501,10 @@ func (l *Log) GC() (int, error) {
 			return n, errors.New("unexpected zero expiration timestamp")
 		}
 		if !le.ExpiresAt.After(now) {
-			l.size -= le.Size()
 			delete(l.st, k)
 			n++
 		}
 	}
-	l.metrics.size.Set(float64(l.size))
 
 	return n, nil
 }
@@ -591,12 +553,6 @@ func (l *Log) loadSnapshot(r io.Reader) error {
 
 	l.mtx.Lock()
 	l.st = st
-	l.size = st.sizeBytes()
-	// A snapshot loaded on startup may already exceed the limit (e.g. it predates
-	// the limit, or grew while the limit was unset), so trim it now rather than
-	// waiting for the next local write.
-	l.evictToLimit()
-	l.metrics.size.Set(float64(l.size))
 	l.mtx.Unlock()
 
 	return nil
@@ -610,7 +566,7 @@ func (l *Log) Snapshot(w io.Writer) (int64, error) {
 	l.mtx.RLock()
 	defer l.mtx.RUnlock()
 
-	b, err := l.st.MarshalBinary()
+	b, err := l.marshalStateWithinLimit()
 	if err != nil {
 		return 0, err
 	}
@@ -623,7 +579,7 @@ func (l *Log) MarshalBinary() ([]byte, error) {
 	l.mtx.Lock()
 	defer l.mtx.Unlock()
 
-	return l.st.MarshalBinary()
+	return l.marshalStateWithinLimit()
 }
 
 // Merge merges notification log state received from the cluster with the local state.
@@ -637,9 +593,7 @@ func (l *Log) Merge(b []byte) error {
 	now := l.now()
 
 	for _, e := range st {
-		merged, delta := l.st.merge(e, now)
-		l.size += delta
-		if merged && !l.isReliableDelivery(b) {
+		if merged := l.st.merge(e, now); merged && !l.isReliableDelivery(b) {
 			// If this is the first we've seen the message and it was
 			// not sent reliably to all nodes, gossip it to other nodes.
 			// We don't propagate reliable messages because they're
@@ -649,11 +603,6 @@ func (l *Log) Merge(b []byte) error {
 			level.Debug(l.logger).Log("msg", "gossiping new entry", "entry", e)
 		}
 	}
-	// Entries also arrive via Merge from peers, not just local Log writes, so
-	// enforce the size limit here as well. Otherwise the log could grow past the
-	// limit on a node that rarely writes locally.
-	l.evictToLimit()
-	l.metrics.size.Set(float64(l.size))
 	return nil
 }
 

--- a/nflog/nflog.go
+++ b/nflog/nflog.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"math/rand"
 	"os"
+	"sort"
 	"sync"
 	"time"
 
@@ -81,13 +82,30 @@ type Log struct {
 	logger    log.Logger
 	metrics   *metrics
 	retention time.Duration
+	limits    Limits
 
 	// For now we only store the most recently added log entry.
 	// The key is a serialized concatenation of group key and receiver.
-	mtx                sync.RWMutex
-	st                 state
+	mtx sync.RWMutex
+	st  state
+	// size is the running sum of the marshaled sizes of all entries in st, used to
+	// enforce Limits.MaxSizeBytes without recomputing the whole state on each write.
+	size               int
 	broadcast          func([]byte)
 	isReliableDelivery func([]byte) bool
+}
+
+// Limits contains the limits for the notification log.
+type Limits struct {
+	// MaxSizeBytes limits the total marshaled size of the notification log in
+	// bytes. If nil, or the returned value is negative or 0, there is no limit.
+	//
+	// When recording a notification would push the log over the limit, existing
+	// entries are evicted until it fits again: resolved entries first, then oldest
+	// by last-notification time. Because the notification has already been sent by
+	// the time it is logged, an evicted group is at worst re-notified later (a
+	// duplicate), never missed.
+	MaxSizeBytes func() int
 }
 
 // MaintenanceFunc represents the function to run as part of the periodic maintenance for the nflog.
@@ -104,6 +122,8 @@ type metrics struct {
 	propagatedMessagesTotal prometheus.Counter
 	maintenanceTotal        prometheus.Counter
 	maintenanceErrorsTotal  prometheus.Counter
+	size                    prometheus.Gauge
+	entriesEvictedTotal     prometheus.Counter
 }
 
 func newMetrics(r prometheus.Registerer) *metrics {
@@ -151,6 +171,14 @@ func newMetrics(r prometheus.Registerer) *metrics {
 		Name: "alertmanager_nflog_gossip_messages_propagated_total",
 		Help: "Number of received gossip messages that have been further gossiped.",
 	})
+	m.size = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "alertmanager_nflog_size_bytes",
+		Help: "Current total marshaled size of the notification log in bytes.",
+	})
+	m.entriesEvictedTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "alertmanager_nflog_entries_evicted_total",
+		Help: "Number of notification log entries evicted (oldest first) to keep the log within the configured maximum size.",
+	})
 
 	if r != nil {
 		r.MustRegister(
@@ -163,6 +191,8 @@ func newMetrics(r prometheus.Registerer) *metrics {
 			m.propagatedMessagesTotal,
 			m.maintenanceTotal,
 			m.maintenanceErrorsTotal,
+			m.size,
+			m.entriesEvictedTotal,
 		)
 	}
 	return m
@@ -178,20 +208,36 @@ func (s state) clone() state {
 	return c
 }
 
-// merge returns true or false whether the MeshEntry was merged or
-// not. This information is used to decide to gossip the message further.
-func (s state) merge(e *pb.MeshEntry, now time.Time) bool {
+// merge stores the entry if it is newer than the existing one for its key. It
+// returns whether the entry was stored (used to decide whether to gossip the
+// message further) and the resulting change (in bytes) to the total marshaled size
+// of the state.
+func (s state) merge(e *pb.MeshEntry, now time.Time) (bool, int) {
 	if e.ExpiresAt.Before(now) {
-		return false
+		return false, 0
 	}
 	k := stateKey(string(e.Entry.GroupKey), e.Entry.Receiver)
 
 	prev, ok := s[k]
-	if !ok || prev.Entry.Timestamp.Before(e.Entry.Timestamp) {
+	if !ok {
 		s[k] = e
-		return true
+		return true, e.Size()
 	}
-	return false
+	if prev.Entry.Timestamp.Before(e.Entry.Timestamp) {
+		s[k] = e
+		return true, e.Size() - prev.Size()
+	}
+	return false, 0
+}
+
+// sizeBytes returns the sum of the marshaled sizes of all entries. This matches
+// the unit tracked incrementally by Log.size.
+func (s state) sizeBytes() int {
+	var n int
+	for _, e := range s {
+		n += e.Size()
+	}
+	return n
 }
 
 func (s state) MarshalBinary() ([]byte, error) {
@@ -239,6 +285,7 @@ type Options struct {
 	SnapshotFile   string
 
 	Retention time.Duration
+	Limits    Limits
 
 	Logger  log.Logger
 	Metrics prometheus.Registerer
@@ -262,6 +309,7 @@ func New(o Options) (*Log, error) {
 	l := &Log{
 		clock:              clock.New(),
 		retention:          o.Retention,
+		limits:             o.Limits,
 		logger:             log.NewNopLogger(),
 		st:                 state{},
 		broadcast:          func([]byte) {},
@@ -387,10 +435,11 @@ func (l *Log) Log(r *pb.Receiver, gkey string, firingAlerts, resolvedAlerts []ui
 	l.mtx.Lock()
 	defer l.mtx.Unlock()
 
-	if prevle, ok := l.st[key]; ok {
+	_, isUpdate := l.st[key]
+	if isUpdate {
 		// Entry already exists, only overwrite if timestamp is newer.
 		// This may happen with raciness or clock-drift across AM nodes.
-		if prevle.Entry.Timestamp.After(now) {
+		if l.st[key].Entry.Timestamp.After(now) {
 			return nil
 		}
 	}
@@ -415,10 +464,61 @@ func (l *Log) Log(r *pb.Receiver, gkey string, firingAlerts, resolvedAlerts []ui
 	if err != nil {
 		return err
 	}
-	l.st.merge(e, l.now())
+
+	_, delta := l.st.merge(e, l.now())
+	l.size += delta
+
+	// Enforce the size limit by evicting existing entries (resolved first, then
+	// oldest by last-notification time) until the log is within the limit. Evicting
+	// rather than rejecting the new entry keeps the most recently active groups
+	// recorded. The evicted entries are the least likely to be re-notified. The
+	// notification has already been sent by this point, so at worst this re-notifies
+	// an evicted group (a duplicate) later, never a missed notification.
+	l.evictToLimit()
+
+	l.metrics.size.Set(float64(l.size))
 	l.broadcast(b)
 
 	return nil
+}
+
+// evictToLimit removes entries until the total marshaled size is within
+// Limits.MaxSizeBytes, preferring resolved entries and then the oldest (by last
+// notification time). Caller must hold l.mtx.
+func (l *Log) evictToLimit() {
+	if l.limits.MaxSizeBytes == nil {
+		return
+	}
+	max := l.limits.MaxSizeBytes()
+	if max <= 0 || l.size <= max {
+		return
+	}
+
+	// Order the evictable keys resolved-first, then oldest-first within each tier.
+	// Evicting a resolved entry (no firing alerts) risks at most a duplicate
+	// resolved notification, whereas evicting a firing entry risks a duplicate page,
+	// so drop the harmless records before the harmful ones.
+	keys := make([]string, 0, len(l.st))
+	for k := range l.st {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		ei, ej := l.st[keys[i]].Entry, l.st[keys[j]].Entry
+		ri, rj := len(ei.FiringAlerts) == 0, len(ej.FiringAlerts) == 0
+		if ri != rj {
+			return ri // resolved (no firing alerts) evicted first
+		}
+		return ei.Timestamp.Before(ej.Timestamp) // then oldest-first
+	})
+
+	for _, k := range keys {
+		if l.size <= max {
+			break
+		}
+		l.size -= l.st[k].Size()
+		delete(l.st, k)
+		l.metrics.entriesEvictedTotal.Inc()
+	}
 }
 
 // GC implements the Log interface.
@@ -437,10 +537,12 @@ func (l *Log) GC() (int, error) {
 			return n, errors.New("unexpected zero expiration timestamp")
 		}
 		if !le.ExpiresAt.After(now) {
+			l.size -= le.Size()
 			delete(l.st, k)
 			n++
 		}
 	}
+	l.metrics.size.Set(float64(l.size))
 
 	return n, nil
 }
@@ -489,6 +591,7 @@ func (l *Log) loadSnapshot(r io.Reader) error {
 
 	l.mtx.Lock()
 	l.st = st
+	l.size = st.sizeBytes()
 	l.mtx.Unlock()
 
 	return nil
@@ -529,7 +632,9 @@ func (l *Log) Merge(b []byte) error {
 	now := l.now()
 
 	for _, e := range st {
-		if merged := l.st.merge(e, now); merged && !l.isReliableDelivery(b) {
+		merged, delta := l.st.merge(e, now)
+		l.size += delta
+		if merged && !l.isReliableDelivery(b) {
 			// If this is the first we've seen the message and it was
 			// not sent reliably to all nodes, gossip it to other nodes.
 			// We don't propagate reliable messages because they're
@@ -539,6 +644,7 @@ func (l *Log) Merge(b []byte) error {
 			level.Debug(l.logger).Log("msg", "gossiping new entry", "entry", e)
 		}
 	}
+	l.metrics.size.Set(float64(l.size))
 	return nil
 }
 

--- a/nflog/nflog.go
+++ b/nflog/nflog.go
@@ -452,8 +452,14 @@ func (l *Log) marshalStateWithinLimit() ([]byte, error) {
 		return l.st.MarshalBinary()
 	}
 
+	// Skip expired entries: a peer discards them on merge, so they would only waste
+	// budget and push out live entries.
+	now := l.now()
 	keys := make([]string, 0, len(l.st))
-	for k := range l.st {
+	for k, e := range l.st {
+		if e.ExpiresAt.Before(now) {
+			continue
+		}
 		keys = append(keys, k)
 	}
 	sort.Slice(keys, func(i, j int) bool {

--- a/nflog/nflog.go
+++ b/nflog/nflog.go
@@ -94,12 +94,11 @@ type Log struct {
 
 // Limits contains the limits for the notification log.
 type Limits struct {
-	// MaxSizeBytes limits the serialized size (in bytes) of the notification log
-	// used for snapshots and state replication. When it is exceeded, the
-	// lowest-priority entries (resolved and oldest first) are omitted from the
-	// serialized copy. The in-memory log is never trimmed. Negative or 0 means no
-	// limit.
-	MaxSizeBytes func() int
+	// MaxSnapshotSizeBytes limits the serialized size of the notification log snapshot.
+	// When it would exceed the limit, entries are dropped from the serialized copy,
+	// preferring to keep firing over resolved, and newer over older.
+	// The in-memory log is never trimmed. Negative or 0 means no limit.
+	MaxSnapshotSizeBytes func() int
 }
 
 // MaintenanceFunc represents the function to run as part of the periodic maintenance for the nflog.
@@ -441,13 +440,13 @@ func (l *Log) Log(r *pb.Receiver, gkey string, firingAlerts, resolvedAlerts []ui
 	return nil
 }
 
-// marshalStateWithinLimit serializes the log without modifying it, keeping entries
-// in priority order (firing before resolved, newest before oldest) up to
-// Limits.MaxSizeBytes and omitting the rest. Caller must hold l.mtx.
+// marshalStateWithinLimit serializes the log without modifying it, dropping entries
+// to fit Limits.MaxSnapshotSizeBytes and preferring to keep firing over resolved
+// and newer over older. Caller must hold l.mtx.
 func (l *Log) marshalStateWithinLimit() ([]byte, error) {
 	max := 0
-	if l.limits.MaxSizeBytes != nil {
-		max = l.limits.MaxSizeBytes()
+	if l.limits.MaxSnapshotSizeBytes != nil {
+		max = l.limits.MaxSnapshotSizeBytes()
 	}
 	if max <= 0 {
 		return l.st.MarshalBinary()

--- a/nflog/nflog_test.go
+++ b/nflog/nflog_test.go
@@ -77,76 +77,52 @@ func TestLogMaxSizeBytes(t *testing.T) {
 		}
 	}
 
-	// Measure one entry's size (limit 0 = no eviction).
+	// Measure one entry's serialized size with no limit.
 	measure := newLog(0)
 	require.NoError(t, measure.Log(rcv(1), "gk1", []uint64{1}, nil, 0))
-	entrySize := measure.size
+	one, err := measure.MarshalBinary()
+	require.NoError(t, err)
+	entrySize := len(one)
 	require.Positive(t, entrySize)
 
-	// Allow between two and three entries so two fit comfortably and a third evicts.
+	// Room for ~2 entries once serialized.
 	l := newLog(2*entrySize + entrySize/2)
-	require.NoError(t, l.Log(rcv(1), "gk1", []uint64{1}, nil, 0))
 	mockClock.Add(time.Second)
-	require.NoError(t, l.Log(rcv(2), "gk2", []uint64{2}, nil, 0))
-	require.Len(t, l.st, 2)
+	require.NoError(t, l.Log(rcv(1), "gk1", []uint64{1}, nil, 0)) // firing, oldest
+	mockClock.Add(time.Second)
+	require.NoError(t, l.Log(rcv(2), "gk2", nil, []uint64{2}, 0)) // resolved
+	mockClock.Add(time.Second)
+	require.NoError(t, l.Log(rcv(3), "gk3", []uint64{3}, nil, 0)) // firing, newest
 
-	// A third entry evicts the oldest (gk1), keeping the two most recent entries.
-	mockClock.Add(time.Second)
-	require.NoError(t, l.Log(rcv(3), "gk3", []uint64{3}, nil, 0))
-	require.Len(t, l.st, 2)
-	require.LessOrEqual(t, l.size, l.limits.MaxSizeBytes())
-	require.NotContains(t, l.st, stateKey("gk1", rcv(1)))
-	require.Contains(t, l.st, stateKey("gk2", rcv(2)))
-	require.Contains(t, l.st, stateKey("gk3", rcv(3)))
-	require.Equal(t, 1.0, testutil.ToFloat64(l.metrics.entriesEvictedTotal))
+	// The in-memory log is never trimmed, regardless of the limit.
+	require.Len(t, l.st, 3)
 
-	// Updating an existing key never evicts and never rejects.
-	mockClock.Add(time.Second)
-	require.NoError(t, l.Log(rcv(2), "gk2", []uint64{2, 3}, nil, 0))
-	require.Len(t, l.st, 2)
-	require.Contains(t, l.st, stateKey("gk2", rcv(2)))
+	// Serializing trims to the limit, keeping firing/newest and dropping the
+	// resolved entry first.
+	b, err := l.MarshalBinary()
+	require.NoError(t, err)
+	require.LessOrEqual(t, len(b), l.limits.MaxSizeBytes())
+	loaded, err := decodeState(bytes.NewReader(b))
+	require.NoError(t, err)
+	require.Len(t, loaded, 2)
+	require.Contains(t, loaded, stateKey("gk3", rcv(3)))    // newest firing kept
+	require.Contains(t, loaded, stateKey("gk1", rcv(1)))    // firing kept over resolved
+	require.NotContains(t, loaded, stateKey("gk2", rcv(2))) // resolved dropped first
+	require.Equal(t, 1.0, testutil.ToFloat64(l.metrics.snapshotEntriesDropped))
 
-	// Eviction prefers resolved entries over older firing entries.
-	lr := newLog(2*entrySize + entrySize/2)
-	mockClock.Add(time.Second)
-	require.NoError(t, lr.Log(rcv(1), "gk1", []uint64{1}, nil, 0)) // firing, oldest
-	mockClock.Add(time.Second)
-	require.NoError(t, lr.Log(rcv(2), "gk2", nil, []uint64{2}, 0)) // resolved, newer
-	require.Len(t, lr.st, 2)
-	mockClock.Add(time.Second)
-	require.NoError(t, lr.Log(rcv(3), "gk3", []uint64{3}, nil, 0)) // firing, newest, triggers eviction
-	require.Len(t, lr.st, 2)
-	require.NotContains(t, lr.st, stateKey("gk2", rcv(2)), "resolved entry should be evicted first")
-	require.Contains(t, lr.st, stateKey("gk1", rcv(1)), "older firing entry should be retained over a resolved one")
-	require.Contains(t, lr.st, stateKey("gk3", rcv(3)))
+	// Serializing does not modify the in-memory log.
+	require.Len(t, l.st, 3)
 
-	// A limit of 0 disables eviction.
+	// With no limit, everything is serialized.
 	l0 := newLog(0)
 	require.NoError(t, l0.Log(rcv(1), "gk1", []uint64{1}, nil, 0))
 	require.NoError(t, l0.Log(rcv(2), "gk2", []uint64{2}, nil, 0))
 	require.NoError(t, l0.Log(rcv(3), "gk3", []uint64{3}, nil, 0))
-	require.Len(t, l0.st, 3)
-
-	// Build a marshaled state with more entries than the limit allows.
-	src := newLog(0)
-	for _, gk := range []string{"mg1", "mg2", "mg3", "mg4", "mg5"} {
-		mockClock.Add(time.Second)
-		require.NoError(t, src.Log(rcv(1), gk, []uint64{1}, nil, 0))
-	}
-	b, err := src.st.MarshalBinary()
+	b0, err := l0.MarshalBinary()
 	require.NoError(t, err)
-
-	// Merge (gossip) enforces the limit, not just local writes.
-	lm := newLog(2*entrySize + entrySize/2)
-	require.NoError(t, lm.Merge(b))
-	require.LessOrEqual(t, lm.size, lm.limits.MaxSizeBytes())
-	require.Positive(t, testutil.ToFloat64(lm.metrics.entriesEvictedTotal))
-
-	// loadSnapshot enforces the limit for state loaded on startup.
-	lsnap := newLog(2*entrySize + entrySize/2)
-	require.NoError(t, lsnap.loadSnapshot(bytes.NewReader(b)))
-	require.LessOrEqual(t, lsnap.size, lsnap.limits.MaxSizeBytes())
-	require.Positive(t, testutil.ToFloat64(lsnap.metrics.entriesEvictedTotal))
+	loaded0, err := decodeState(bytes.NewReader(b0))
+	require.NoError(t, err)
+	require.Len(t, loaded0, 3)
 }
 
 func TestLogSnapshot(t *testing.T) {
@@ -211,7 +187,7 @@ func TestLogSnapshot(t *testing.T) {
 		require.NoError(t, err, "opening snapshot file failed")
 
 		// Check again against new nlog instance.
-		l2 := &Log{metrics: newMetrics(nil)}
+		l2 := &Log{}
 		err = l2.loadSnapshot(f)
 		require.NoError(t, err, "error loading snapshot")
 		require.Equal(t, l1.st, l2.st, "state after loading snapshot did not match snapshotted state")

--- a/nflog/nflog_test.go
+++ b/nflog/nflog_test.go
@@ -60,7 +60,7 @@ func TestLogGC(t *testing.T) {
 	require.Equal(t, expected, l.st, "unexpected state after garbage collection")
 }
 
-func TestLogMaxSizeBytes(t *testing.T) {
+func TestLogMaxSnapshotSizeBytes(t *testing.T) {
 	mockClock := clock.NewMock()
 	rcv := func(i int) *pb.Receiver {
 		return &pb.Receiver{GroupName: "g", Integration: "test", Idx: uint32(i)}
@@ -69,7 +69,7 @@ func TestLogMaxSizeBytes(t *testing.T) {
 		return &Log{
 			clock:              mockClock,
 			retention:          time.Hour,
-			limits:             Limits{MaxSizeBytes: func() int { return limit }},
+			limits:             Limits{MaxSnapshotSizeBytes: func() int { return limit }},
 			st:                 state{},
 			broadcast:          func([]byte) {},
 			isReliableDelivery: func([]byte) bool { return true },
@@ -101,7 +101,7 @@ func TestLogMaxSizeBytes(t *testing.T) {
 	// resolved entry first.
 	b, err := l.MarshalBinary()
 	require.NoError(t, err)
-	require.LessOrEqual(t, len(b), l.limits.MaxSizeBytes())
+	require.LessOrEqual(t, len(b), l.limits.MaxSnapshotSizeBytes())
 	loaded, err := decodeState(bytes.NewReader(b))
 	require.NoError(t, err)
 	require.Len(t, loaded, 2)

--- a/nflog/nflog_test.go
+++ b/nflog/nflog_test.go
@@ -60,6 +60,73 @@ func TestLogGC(t *testing.T) {
 	require.Equal(t, expected, l.st, "unexpected state after garbage collection")
 }
 
+func TestLogMaxSizeBytes(t *testing.T) {
+	mockClock := clock.NewMock()
+	rcv := func(i int) *pb.Receiver {
+		return &pb.Receiver{GroupName: "g", Integration: "test", Idx: uint32(i)}
+	}
+	newLog := func(limit int) *Log {
+		return &Log{
+			clock:     mockClock,
+			retention: time.Hour,
+			limits:    Limits{MaxSizeBytes: func() int { return limit }},
+			st:        state{},
+			broadcast: func([]byte) {},
+			metrics:   newMetrics(nil),
+		}
+	}
+
+	// Measure one entry's size (limit 0 = no eviction).
+	measure := newLog(0)
+	require.NoError(t, measure.Log(rcv(1), "gk1", []uint64{1}, nil, 0))
+	entrySize := measure.size
+	require.Positive(t, entrySize)
+
+	// Allow between two and three entries so two fit comfortably and a third evicts.
+	l := newLog(2*entrySize + entrySize/2)
+	require.NoError(t, l.Log(rcv(1), "gk1", []uint64{1}, nil, 0))
+	mockClock.Add(time.Second)
+	require.NoError(t, l.Log(rcv(2), "gk2", []uint64{2}, nil, 0))
+	require.Len(t, l.st, 2)
+
+	// A third entry evicts the oldest (gk1), keeping the two most recent entries.
+	mockClock.Add(time.Second)
+	require.NoError(t, l.Log(rcv(3), "gk3", []uint64{3}, nil, 0))
+	require.Len(t, l.st, 2)
+	require.LessOrEqual(t, l.size, l.limits.MaxSizeBytes())
+	require.NotContains(t, l.st, stateKey("gk1", rcv(1)))
+	require.Contains(t, l.st, stateKey("gk2", rcv(2)))
+	require.Contains(t, l.st, stateKey("gk3", rcv(3)))
+	require.Equal(t, 1.0, testutil.ToFloat64(l.metrics.entriesEvictedTotal))
+
+	// Updating an existing key never evicts and never rejects.
+	mockClock.Add(time.Second)
+	require.NoError(t, l.Log(rcv(2), "gk2", []uint64{2, 3}, nil, 0))
+	require.Len(t, l.st, 2)
+	require.Contains(t, l.st, stateKey("gk2", rcv(2)))
+
+	// Eviction prefers resolved entries over older firing entries.
+	lr := newLog(2*entrySize + entrySize/2)
+	mockClock.Add(time.Second)
+	require.NoError(t, lr.Log(rcv(1), "gk1", []uint64{1}, nil, 0)) // firing, oldest
+	mockClock.Add(time.Second)
+	require.NoError(t, lr.Log(rcv(2), "gk2", nil, []uint64{2}, 0)) // resolved, newer
+	require.Len(t, lr.st, 2)
+	mockClock.Add(time.Second)
+	require.NoError(t, lr.Log(rcv(3), "gk3", []uint64{3}, nil, 0)) // firing, newest, triggers eviction
+	require.Len(t, lr.st, 2)
+	require.NotContains(t, lr.st, stateKey("gk2", rcv(2)), "resolved entry should be evicted first")
+	require.Contains(t, lr.st, stateKey("gk1", rcv(1)), "older firing entry should be retained over a resolved one")
+	require.Contains(t, lr.st, stateKey("gk3", rcv(3)))
+
+	// A limit of 0 disables eviction.
+	l0 := newLog(0)
+	require.NoError(t, l0.Log(rcv(1), "gk1", []uint64{1}, nil, 0))
+	require.NoError(t, l0.Log(rcv(2), "gk2", []uint64{2}, nil, 0))
+	require.NoError(t, l0.Log(rcv(3), "gk3", []uint64{3}, nil, 0))
+	require.Len(t, l0.st, 3)
+}
+
 func TestLogSnapshot(t *testing.T) {
 	// Check whether storing and loading the snapshot is symmetric.
 	mockClock := clock.NewMock()

--- a/nflog/nflog_test.go
+++ b/nflog/nflog_test.go
@@ -113,6 +113,24 @@ func TestLogMaxSnapshotSizeBytes(t *testing.T) {
 	// Serializing does not modify the in-memory log.
 	require.Len(t, l.st, 3)
 
+	// Expired entries are excluded from the serialized snapshot (they would be
+	// discarded on merge anyway) and do not consume budget.
+	le := newLog(1 << 20) // generous limit, so exclusion is due to expiry, not size
+	mockClock.Add(time.Second)
+	require.NoError(t, le.Log(rcv(1), "live", []uint64{1}, nil, 0))
+	le.st[stateKey("expired", rcv(2))] = &pb.MeshEntry{
+		Entry:     &pb.Entry{Receiver: rcv(2), GroupKey: []byte("expired"), Timestamp: mockClock.Now(), FiringAlerts: []uint64{2}},
+		ExpiresAt: mockClock.Now().Add(-time.Hour),
+	}
+	require.Len(t, le.st, 2)
+	be, err := le.MarshalBinary()
+	require.NoError(t, err)
+	loadedE, err := decodeState(bytes.NewReader(be))
+	require.NoError(t, err)
+	require.Len(t, loadedE, 1)
+	require.Contains(t, loadedE, stateKey("live", rcv(1)))
+	require.NotContains(t, loadedE, stateKey("expired", rcv(2)))
+
 	// With no limit, everything is serialized.
 	l0 := newLog(0)
 	require.NoError(t, l0.Log(rcv(1), "gk1", []uint64{1}, nil, 0))

--- a/nflog/nflog_test.go
+++ b/nflog/nflog_test.go
@@ -67,12 +67,13 @@ func TestLogMaxSizeBytes(t *testing.T) {
 	}
 	newLog := func(limit int) *Log {
 		return &Log{
-			clock:     mockClock,
-			retention: time.Hour,
-			limits:    Limits{MaxSizeBytes: func() int { return limit }},
-			st:        state{},
-			broadcast: func([]byte) {},
-			metrics:   newMetrics(nil),
+			clock:              mockClock,
+			retention:          time.Hour,
+			limits:             Limits{MaxSizeBytes: func() int { return limit }},
+			st:                 state{},
+			broadcast:          func([]byte) {},
+			isReliableDelivery: func([]byte) bool { return true },
+			metrics:            newMetrics(nil),
 		}
 	}
 
@@ -125,6 +126,27 @@ func TestLogMaxSizeBytes(t *testing.T) {
 	require.NoError(t, l0.Log(rcv(2), "gk2", []uint64{2}, nil, 0))
 	require.NoError(t, l0.Log(rcv(3), "gk3", []uint64{3}, nil, 0))
 	require.Len(t, l0.st, 3)
+
+	// Build a marshaled state with more entries than the limit allows.
+	src := newLog(0)
+	for _, gk := range []string{"mg1", "mg2", "mg3", "mg4", "mg5"} {
+		mockClock.Add(time.Second)
+		require.NoError(t, src.Log(rcv(1), gk, []uint64{1}, nil, 0))
+	}
+	b, err := src.st.MarshalBinary()
+	require.NoError(t, err)
+
+	// Merge (gossip) enforces the limit, not just local writes.
+	lm := newLog(2*entrySize + entrySize/2)
+	require.NoError(t, lm.Merge(b))
+	require.LessOrEqual(t, lm.size, lm.limits.MaxSizeBytes())
+	require.Positive(t, testutil.ToFloat64(lm.metrics.entriesEvictedTotal))
+
+	// loadSnapshot enforces the limit for state loaded on startup.
+	lsnap := newLog(2*entrySize + entrySize/2)
+	require.NoError(t, lsnap.loadSnapshot(bytes.NewReader(b)))
+	require.LessOrEqual(t, lsnap.size, lsnap.limits.MaxSizeBytes())
+	require.Positive(t, testutil.ToFloat64(lsnap.metrics.entriesEvictedTotal))
 }
 
 func TestLogSnapshot(t *testing.T) {
@@ -189,7 +211,7 @@ func TestLogSnapshot(t *testing.T) {
 		require.NoError(t, err, "opening snapshot file failed")
 
 		// Check again against new nlog instance.
-		l2 := &Log{}
+		l2 := &Log{metrics: newMetrics(nil)}
 		err = l2.loadSnapshot(f)
 		require.NoError(t, err, "error loading snapshot")
 		require.Equal(t, l1.st, l2.st, "state after loading snapshot did not match snapshotted state")


### PR DESCRIPTION
This PR adds an optional size limit to the notification log snapshot (`nflog.Limits.MaxSnapshotSizeBytes`, 0 = disabled). The in-memory log is never trimmed and keeps gossiping and expiring as usual.

When a serialized snapshot would exceed the limit, entries are packed in priority order, and the rest are omitted from that copy. Keep priority:
1. Firing entries (newest to oldest)
2. Resolved entries (newest to oldest)

Trimming only the serialized copy, rather than evicting from the in-memory log, keeps the dedup records intact so there is no re-notification churn (an at-limit tenant repeatedly re-sending notifications, including the same notification from the different instances that own a tenant in Mimir). Omitted entries are dropped only from the serialized copy, so a peer or a restarting replica that loads it may re-notify those groups (a duplicate), never miss a notification.

Consumers wire a per-tenant limit via `nflog.Options.Limits`. Adds `alertmanager_nflog_snapshot_entries_dropped_total`. This bounds the persisted and replicated state (driven by a tenant's alert-instance count) so it stays small enough to replicate and read back, which is what failed in the incident.
