### PR TITLE
Base nflog entry expiry on max(repeat, group) interval

### DIFF
--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -507,6 +507,7 @@ func (ag *aggrGroup) run(nf notifyFunc) {
 			ctx = notify.WithGroupLabels(ctx, ag.labels)
 			ctx = notify.WithReceiverName(ctx, ag.opts.Receiver)
 			ctx = notify.WithRepeatInterval(ctx, ag.opts.RepeatInterval)
+			ctx = notify.WithGroupInterval(ctx, ag.opts.GroupInterval)
 			ctx = notify.WithMuteTimeIntervals(ctx, ag.opts.MuteTimeIntervals)
 			ctx = notify.WithActiveTimeIntervals(ctx, ag.opts.ActiveTimeIntervals)
 

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -125,6 +125,7 @@ type notifyKey int
 const (
 	keyReceiverName notifyKey = iota
 	keyRepeatInterval
+	keyGroupInterval
 	keyGroupLabels
 	keyGroupKey
 	keyFiringAlerts
@@ -169,6 +170,11 @@ func WithRepeatInterval(ctx context.Context, t time.Duration) context.Context {
 	return context.WithValue(ctx, keyRepeatInterval, t)
 }
 
+// WithGroupInterval populates a context with a group interval.
+func WithGroupInterval(ctx context.Context, t time.Duration) context.Context {
+	return context.WithValue(ctx, keyGroupInterval, t)
+}
+
 // WithMuteTimeIntervals populates a context with a slice of mute time names.
 func WithMuteTimeIntervals(ctx context.Context, mt []string) context.Context {
 	return context.WithValue(ctx, keyMuteTimeIntervals, mt)
@@ -182,6 +188,13 @@ func WithActiveTimeIntervals(ctx context.Context, at []string) context.Context {
 // second argument is false.
 func RepeatInterval(ctx context.Context) (time.Duration, bool) {
 	v, ok := ctx.Value(keyRepeatInterval).(time.Duration)
+	return v, ok
+}
+
+// GroupInterval extracts a group interval from the context. Iff none exists, the
+// second argument is false.
+func GroupInterval(ctx context.Context) (time.Duration, bool) {
+	v, ok := ctx.Value(keyGroupInterval).(time.Duration)
 	return v, ok
 }
 
@@ -948,7 +961,15 @@ func (n SetNotifiesStage) Exec(ctx context.Context, l log.Logger, alerts ...*typ
 	if !ok {
 		return ctx, nil, errors.New("repeat interval missing")
 	}
+
+	// The nflog entry must outlive the group's flush cadence, not just the repeat cycle.
+	// A resolved notification can only be emitted at a flush (group_interval) and needs the firing entry to still be present.
+	// With only 2*repeat, a group_interval larger than 2*repeat_interval lets the entry be swept before the resolve is flushed,
+	// silently dropping the resolved notification.
 	expiry := 2 * repeat
+	if groupInterval, ok := GroupInterval(ctx); ok && groupInterval > repeat {
+		expiry = 2 * groupInterval
+	}
 
 	return ctx, alerts, n.nflog.Log(n.recv, gkey, firing, resolved, expiry)
 }

--- a/notify/notify_test.go
+++ b/notify/notify_test.go
@@ -688,6 +688,60 @@ func TestSetNotifiesStage(t *testing.T) {
 	require.NotNil(t, resctx)
 }
 
+func TestSetNotifiesStageEntryExpiry(t *testing.T) {
+	// The nflog entry must outlive the group's flush cadence so a later resolve
+	// flush can still find the firing entry: expiry is 2*max(repeat, group).
+	tnflog := &testNflog{}
+	s := &SetNotifiesStage{
+		recv:  &nflogpb.Receiver{GroupName: "test"},
+		nflog: tnflog,
+	}
+	alerts := []*types.Alert{{}, {}, {}}
+	base := WithResolvedAlerts(WithFiringAlerts(WithGroupKey(context.Background(), "1"), []uint64{0, 1, 2}), []uint64{})
+
+	for _, tc := range []struct {
+		name           string
+		repeatInterval time.Duration
+		groupInterval  time.Duration // 0 => not populated in the context
+		expectedExpiry time.Duration
+	}{
+		{
+			name:           "group_interval larger than repeat: expiry follows group_interval",
+			repeatInterval: 5 * time.Minute,
+			groupInterval:  time.Hour,
+			expectedExpiry: 2 * time.Hour,
+		},
+		{
+			name:           "repeat larger than group_interval (heartbeat): expiry follows repeat",
+			repeatInterval: 4 * time.Hour,
+			groupInterval:  time.Minute,
+			expectedExpiry: 8 * time.Hour,
+		},
+		{
+			name:           "group_interval absent: expiry follows repeat",
+			repeatInterval: time.Hour,
+			groupInterval:  0,
+			expectedExpiry: 2 * time.Hour,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := WithRepeatInterval(base, tc.repeatInterval)
+			if tc.groupInterval > 0 {
+				ctx = WithGroupInterval(ctx, tc.groupInterval)
+			}
+			var gotExpiry time.Duration
+			tnflog.logFunc = func(_ *nflogpb.Receiver, _ string, _, _ []uint64, expiry time.Duration) error {
+				gotExpiry = expiry
+				return nil
+			}
+			_, res, err := s.Exec(ctx, log.NewNopLogger(), alerts...)
+			require.NoError(t, err)
+			require.Equal(t, alerts, res)
+			require.Equal(t, tc.expectedExpiry, gotExpiry)
+		})
+	}
+}
+
 func TestMuteStage(t *testing.T) {
 	// Mute all label sets that have a "mute" key.
 	muter := types.MuteFunc(func(lset model.LabelSet) bool {


### PR DESCRIPTION
Notification-log entries expire after `2 * repeat_interval`, which assumes `repeat_interval >= group_interval`. A group is only flushed every `group_interval`, and a resolved notification is emitted at a flush and needs the firing entry to still be present.

When a route has `group_interval` larger than `2 * repeat_interval`, the firing entry can be swept before the next flush (GC every 30m), so on resolve the `DedupStage` finds no prior entry and silently drops the resolved notification (no send, no error).

This PR bases the entry expiry on `2 * max(repeat_interval, group_interval)` so the entry always outlives the flush cadence. The `group_interval` is now plumbed into the notification context alongside `repeat_interval`.
